### PR TITLE
feat(runtime): make runtime addressable

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -41,7 +41,6 @@
   "scripts": {
     "build": "tsc --project tsconfig.prod.json",
     "postversion": "pnpm run build",
-    "prebuild": "node -p \"'export const VERSION = ' + JSON.stringify(require('./package.json').version)\" > src/version.ts",
     "test": "jest"
   },
   "license": "MPLv2",

--- a/packages/runtime/src/cli/repl.ts
+++ b/packages/runtime/src/cli/repl.ts
@@ -18,6 +18,13 @@ Object.getOwnPropertyNames(repl.context).forEach(
 const runtime = new EdgeRuntime()
 Object.assign(repl.context, runtime.context)
 
+Object.defineProperty(repl.context, 'EdgeRuntime', {
+  configurable: false,
+  enumerable: false,
+  writable: false,
+  value: runtime.context.EdgeRuntime,
+})
+
 const nodeMajorVersion = parseInt(process.versions.node.split('.')[0])
 if (nodeMajorVersion < 16) {
   repl.context.util = {

--- a/packages/runtime/src/edge-runtime.ts
+++ b/packages/runtime/src/edge-runtime.ts
@@ -5,7 +5,6 @@ import type {
   EdgeVMOptions,
 } from '@edge-runtime/vm'
 import { EdgeVM } from '@edge-runtime/vm'
-import { VERSION } from './version'
 
 interface Options<T extends Primitives> extends EdgeVMOptions<T> {
   /**
@@ -60,7 +59,7 @@ export class EdgeRuntime<T extends Primitives = any> extends EdgeVM<T> {
       configurable: false,
       enumerable: false,
       writable: false,
-      value: { version: VERSION },
+      value: 'edge-runtime',
     })
 
     this.evaluate<void>(getDefineEventListenersCode())

--- a/packages/runtime/tests/edge-runtime.test.ts
+++ b/packages/runtime/tests/edge-runtime.test.ts
@@ -190,8 +190,14 @@ test('gets a server error when responding with no response', async () => {
 
 test('gets the runtime version in a hidden propety', async () => {
   const runtime = new EdgeRuntime()
-  const meta = runtime.evaluate(`(globalThis.EdgeRuntime)`)
-  expect(meta).toEqual({ version: expect.any(String) })
+  {
+    const meta = runtime.evaluate(`(globalThis.EdgeRuntime)`)
+    expect(meta).toEqual('edge-runtime')
+  }
+  {
+    const meta = runtime.evaluate(`(EdgeRuntime)`)
+    expect(meta).toEqual('edge-runtime')
+  }
   const keys = runtime.evaluate<string[]>(`(Object.keys(globalThis))`)
   expect(keys).not.toHaveLength(0)
   expect(keys).not.toContain('EdgeRuntime')


### PR DESCRIPTION
make `EdgeRuntime === 'edge-runtime'` & enable EdgeRuntime as global in the REPL

## Related

- https://github.com/vercel/next.js/pull/38288
