### PR TITLE
fix(runtime): add help for CLI

### DIFF
--- a/packages/runtime/src/cli/help.ts
+++ b/packages/runtime/src/cli/help.ts
@@ -1,31 +1,36 @@
+import { dim, white } from 'picocolors'
 interface HelpOptions extends Record<string, string> {}
 
-const helpSummary = 'Usage: edge-runtime [input] [<flags>]\n'
-
 const flags: HelpOptions = {
-  help: 'Display help message for flags.',
-  listen: 'Interact with edge-runtime as an HTTP server.',
+  eval: 'Evaluate an input script',
+  help: 'Display this message.',
+  listen: 'Run as HTTP server.',
   port: 'Specify a port to use.',
   repl: 'Start an interactive session.',
 }
 
-export function help() {
-  const flagsSummary = getSectionSummary('Flags', flags)
-  const message = [helpSummary, flagsSummary].join('\n')
-  console.log(message)
-}
+export const help = () => `
+  edge-runtime ${dim('[<flags>] [input]')}
+
+  ${dim('Flags:')}
+
+${getSectionSummary(flags)}
+`
 
 function getPadLength(options: HelpOptions) {
   const lengths = Object.keys(options).map((key) => key.length)
-  return Math.max.apply(null, lengths)
+  return Math.max.apply(null, lengths) + 1
 }
 
-function getSectionSummary(title: string, options: HelpOptions) {
+function getSectionSummary(options: HelpOptions) {
   const summaryPadLength = getPadLength(options)
 
   const summary = Object.entries(options)
-    .map(([key, value]) => `  --${key.padEnd(summaryPadLength)} ${value}`)
+    .map(
+      ([key, description]) =>
+        `    --${key.padEnd(summaryPadLength)} ${dim(description)}`
+    )
     .join('\n')
 
-  return `${title}:\n${summary}\n`
+  return `${summary}`
 }

--- a/packages/runtime/src/cli/help.ts
+++ b/packages/runtime/src/cli/help.ts
@@ -1,0 +1,31 @@
+interface HelpOptions extends Record<string, string> {}
+
+const helpSummary = 'Usage: edge-runtime [input] [<flags>]\n'
+
+const flags: HelpOptions = {
+  help: 'Display help message for flags.',
+  listen: 'Interact with edge-runtime as an HTTP server.',
+  port: 'Specify a port to use.',
+  repl: 'Start an interactive session.',
+}
+
+export function help() {
+  const flagsSummary = getSectionSummary('Flags', flags)
+  const message = [helpSummary, flagsSummary].join('\n')
+  console.log(message)
+}
+
+function getPadLength(options: HelpOptions) {
+  const lengths = Object.keys(options).map((key) => key.length)
+  return Math.max.apply(null, lengths)
+}
+
+function getSectionSummary(title: string, options: HelpOptions) {
+  const summaryPadLength = getPadLength(options)
+
+  const summary = Object.entries(options)
+    .map(([key, value]) => `  --${key.padEnd(summaryPadLength)} ${value}`)
+    .join('\n')
+
+  return `${title}:\n${summary}\n`
+}

--- a/packages/runtime/src/cli/index.ts
+++ b/packages/runtime/src/cli/index.ts
@@ -12,11 +12,13 @@ import path from 'path'
 const { _: input, ...flags } = mri(process.argv.slice(2), {
   alias: {
     e: 'eval',
+    h: 'help',
     l: 'listen',
     p: 'port',
   },
   default: {
     cwd: process.cwd(),
+    help: false,
     listen: false,
     port: 3000,
     repl: false,
@@ -25,6 +27,11 @@ const { _: input, ...flags } = mri(process.argv.slice(2), {
 })
 
 async function main() {
+  if (flags.help) {
+    const { help } = await import('./help')
+    return help()
+  }
+
   if (flags.eval) {
     const { inlineEval } = await import('./eval')
     console.log(await inlineEval(input[0]))

--- a/packages/runtime/src/cli/index.ts
+++ b/packages/runtime/src/cli/index.ts
@@ -29,7 +29,8 @@ const { _: input, ...flags } = mri(process.argv.slice(2), {
 async function main() {
   if (flags.help) {
     const { help } = await import('./help')
-    return help()
+    console.log(help())
+    return
   }
 
   if (flags.eval) {


### PR DESCRIPTION
- Fixes https://github.com/vercel/edge-runtime/issues/6
- Doc: https://edge-runtime.vercel.app/cli
- This PR adds missing `help` flag for `edge-runtime` cli

```
$ edge-runtime --help
Usage: edge-runtime [input] [<flags>]

Flags:
  --help   Display help message for flags.
  --listen Interact with edge-runtime as an HTTP server.
  --port   Specify a port to use.
  --repl   Start an interactive session.

```