### PR TITLE
feat(cli): add `--eval` flag

### DIFF
--- a/packages/runtime/src/cli/eval.ts
+++ b/packages/runtime/src/cli/eval.ts
@@ -1,0 +1,7 @@
+import { EdgeRuntime } from '../edge-runtime'
+
+export const inlineEval = async (script: string) => {
+  const runtime = new EdgeRuntime()
+  const result = await runtime.evaluate(script)
+  return result
+}

--- a/packages/runtime/src/cli/logger.ts
+++ b/packages/runtime/src/cli/logger.ts
@@ -1,3 +1,4 @@
+import { createFormat } from '@edge-runtime/format'
 import type { Logger, LoggerOptions } from '../types'
 import type { Formatter } from 'picocolors/types'
 import pico from 'picocolors'
@@ -6,6 +7,8 @@ const isEnabled =
   process.env.EDGE_RUNTIME_LOGGING !== undefined
     ? Boolean(process.env.EDGE_RUNTIME_LOGGING)
     : true
+
+export const format = createFormat()
 
 /**
  * Creates basic logger with colors that can be used from the CLI and the

--- a/packages/runtime/src/cli/repl.ts
+++ b/packages/runtime/src/cli/repl.ts
@@ -16,7 +16,12 @@ Object.getOwnPropertyNames(repl.context).forEach(
 )
 
 const runtime = new EdgeRuntime()
-Object.assign(repl.context, runtime.context)
+
+Object.getOwnPropertyNames(runtime.context)
+  .filter((key) => !key.startsWith('__'))
+  .forEach((key) =>
+    Object.assign(repl.context, { [key]: runtime.context[key] })
+  )
 
 Object.defineProperty(repl.context, 'EdgeRuntime', {
   configurable: false,
@@ -38,3 +43,5 @@ if (nodeMajorVersion < 16) {
     },
   }
 }
+
+export { repl }

--- a/packages/runtime/src/edge-runtime.ts
+++ b/packages/runtime/src/edge-runtime.ts
@@ -23,14 +23,16 @@ let uncaughtExceptionHandlers: ErrorHandler[]
  * rejections and FetchEvent. It also allows to dispatch fetch events which
  * enables it to work behind a server.
  */
-export class EdgeRuntime<T extends EdgeContext = EdgeContext> extends EdgeVM<T> {
+export class EdgeRuntime<
+  T extends EdgeContext = EdgeContext
+> extends EdgeVM<T> {
   public readonly dispatchFetch: DispatchFetch
 
   constructor(options?: Options<T>) {
     super({
       ...options,
       extend: (context) => {
-        return options?.extend?.(context) ?? context as EdgeContext & T
+        return options?.extend?.(context) ?? (context as EdgeContext & T)
       },
     })
 
@@ -96,7 +98,7 @@ function getDefineEventListenersCode() {
       writable: true,
     })
 
-    function conditionallyUpdatesHandlerList(eventType) {
+    function __conditionallyUpdatesHandlerList(eventType) {
       if (eventType === 'unhandledrejection') {
         self.__onUnhandledRejectionHandler = self.__listeners[eventType];
       } else if (eventType === 'error') {
@@ -112,7 +114,7 @@ function getDefineEventListenersCode() {
 
       self.__listeners[eventType] = self.__listeners[eventType] || [];
       self.__listeners[eventType].push(handler);
-      conditionallyUpdatesHandlerList(eventType);
+      __conditionallyUpdatesHandlerList(eventType);
     }
 
     function removeEventListener(type, handler) {
@@ -126,7 +128,7 @@ function getDefineEventListenersCode() {
           delete self.__listeners[eventType];
         }
       }
-      conditionallyUpdatesHandlerList(eventType);
+      __conditionallyUpdatesHandlerList(eventType);
     }
   `
 }

--- a/packages/runtime/tests/repl.test.ts
+++ b/packages/runtime/tests/repl.test.ts
@@ -1,0 +1,153 @@
+import { ChildProcess, spawn } from 'child_process'
+import path from 'path'
+
+type ChildPromise = {
+  stdout: string
+  stderr: string
+  code: number
+}
+
+const scriptPath = path.resolve(__dirname, '../dist/cli/index.js')
+
+const childPromise = (subprocess: ChildProcess): Promise<ChildPromise> =>
+  new Promise((resolve) => {
+    let stdout: any = ''
+    let stderr: any = ''
+
+    if (subprocess.stdout) {
+      subprocess.stdout.on('data', (data: any) => (stdout += data.toString()))
+    }
+
+    if (subprocess.stderr) {
+      subprocess.stderr.on('data', (data: any) => (stderr += data.toString()))
+    }
+
+    subprocess.on('close', (code) => resolve({ code, stdout, stderr }))
+  })
+
+describe('contains all required primitives', () => {
+  it.each([
+    { api: 'AbortController' },
+    { api: 'AbortSignal' },
+    { api: 'addEventListener' },
+    { api: 'Array' },
+    { api: 'ArrayBuffer' },
+    { api: 'atob' },
+    { api: 'Atomics' },
+    { api: 'BigInt' },
+    { api: 'BigInt64Array' },
+    { api: 'BigUint64Array' },
+    { api: 'Blob' },
+    { api: 'Boolean' },
+    { api: 'btoa' },
+    { api: 'Cache' },
+    { api: 'caches' },
+    { api: 'caches' },
+    { api: 'CacheStorage' },
+    { api: 'clearInterval' },
+    { api: 'clearTimeout' },
+    { api: 'console' },
+    { api: 'console' },
+    { api: 'crypto' },
+    { api: 'crypto' },
+    { api: 'Crypto' },
+    { api: 'CryptoKey' },
+    { api: 'DataView' },
+    { api: 'Date' },
+    { api: 'decodeURI' },
+    { api: 'decodeURIComponent' },
+    { api: 'encodeURI' },
+    { api: 'encodeURIComponent' },
+    { api: 'Error' },
+    { api: 'Error' },
+    { api: 'escape' },
+    { api: 'eval' },
+    { api: 'EvalError' },
+    { api: 'EvalError' },
+    { api: 'Event' },
+    { api: 'Event' },
+    { api: 'EventTarget' },
+    { api: 'fetch' },
+    { api: 'FetchEvent' },
+    { api: 'File' },
+    { api: 'Float32Array' },
+    { api: 'Float64Array' },
+    { api: 'FormData' },
+    { api: 'Function' },
+    { api: 'globalThis' },
+    { api: 'Headers' },
+    { api: 'Infinity' },
+    { api: 'Int8Array' },
+    { api: 'Int16Array' },
+    { api: 'Int32Array' },
+    { api: 'Intl' },
+    { api: 'isFinite' },
+    { api: 'isNaN' },
+    { api: 'JSON' },
+    { api: 'Map' },
+    { api: 'Math' },
+    { api: 'NaN' },
+    { api: 'Number' },
+    { api: 'Object' },
+    { api: 'parseFloat' },
+    { api: 'parseInt' },
+    { api: 'Promise' },
+    { api: 'PromiseRejectionEvent' },
+    { api: 'Proxy' },
+    { api: 'RangeError' },
+    { api: 'ReadableStream' },
+    { api: 'ReadableStreamBYOBReader' },
+    { api: 'ReadableStreamDefaultReader' },
+    { api: 'ReferenceError' },
+    { api: 'Reflect' },
+    { api: 'RegExp' },
+    { api: 'removeEventListener' },
+    { api: 'Request' },
+    { api: 'Response' },
+    { api: 'self' },
+    { api: 'Set' },
+    { api: 'setInterval' },
+    { api: 'setTimeout' },
+    { api: 'SharedArrayBuffer' },
+    { api: 'String' },
+    { api: 'structuredClone' },
+    { api: 'SubtleCrypto' },
+    { api: 'Symbol' },
+    { api: 'SyntaxError' },
+    { api: 'TextDecoder' },
+    { api: 'TextEncoder' },
+    { api: 'TransformStream' },
+    { api: 'TypeError' },
+    { api: 'Uint8Array' },
+    { api: 'Uint8ClampedArray' },
+    { api: 'Uint16Array' },
+    { api: 'Uint32Array' },
+    { api: 'undefined' },
+    { api: 'unescape' },
+    { api: 'URIError' },
+    { api: 'URL' },
+    { api: 'URLPattern' },
+    { api: 'URLSearchParams' },
+    { api: 'WeakMap' },
+    { api: 'WeakSet' },
+    { api: 'WebAssembly' },
+    { api: 'WritableStream' },
+    { api: 'WritableStreamDefaultWriter' },
+  ])('`$api` is defined in global scope', async ({ api }) => {
+    const assertion = (() => {
+      if (api === 'undefined') return `undefined === ${api}`
+      if (api === 'NaN') return `Number.isNaN(${api})`
+      return `!!${api}`
+    })()
+
+    const cli = spawn('node', [
+      scriptPath,
+      '--eval',
+      `JSON.stringify(${assertion})`,
+    ])
+
+    const { stdout, stderr, code } = await childPromise(cli)
+    expect(code).toBe(0)
+    expect(JSON.parse(stdout)).toBe(true)
+  })
+})

--- a/packages/vm/tests/unit/edge-vm.test.ts
+++ b/packages/vm/tests/unit/edge-vm.test.ts
@@ -261,10 +261,13 @@ describe('contains all required primitives', () => {
     { api: 'btoa' },
     { api: 'Cache' },
     { api: 'caches' },
+    { api: 'caches' },
     { api: 'CacheStorage' },
     { api: 'clearInterval' },
     { api: 'clearTimeout' },
     { api: 'console' },
+    { api: 'console' },
+    { api: 'crypto' },
     { api: 'crypto' },
     { api: 'Crypto' },
     { api: 'CryptoKey' },
@@ -275,7 +278,12 @@ describe('contains all required primitives', () => {
     { api: 'encodeURI' },
     { api: 'encodeURIComponent' },
     { api: 'Error' },
+    { api: 'Error' },
+    { api: 'escape' },
+    { api: 'eval' },
     { api: 'EvalError' },
+    { api: 'EvalError' },
+    { api: 'Event' },
     { api: 'Event' },
     { api: 'EventTarget' },
     { api: 'fetch' },
@@ -297,6 +305,7 @@ describe('contains all required primitives', () => {
     { api: 'JSON' },
     { api: 'Map' },
     { api: 'Math' },
+    { api: 'NaN' },
     { api: 'Number' },
     { api: 'Object' },
     { api: 'parseFloat' },
@@ -331,6 +340,7 @@ describe('contains all required primitives', () => {
     { api: 'Uint8ClampedArray' },
     { api: 'Uint16Array' },
     { api: 'Uint32Array' },
+    { api: 'unescape' },
     { api: 'URIError' },
     { api: 'URL' },
     { api: 'URLPattern' },
@@ -340,7 +350,7 @@ describe('contains all required primitives', () => {
     { api: 'WebAssembly' },
     { api: 'WritableStream' },
     { api: 'WritableStreamDefaultWriter' },
-  ])('$api is defined in global scope', ({ api }) => {
+  ])('`$api` is defined in global scope', ({ api }) => {
     expect(edgeVM.evaluate(api)).toBeDefined()
   })
 })


### PR DESCRIPTION
This PR introduces `--eval` flag to run any inline script:

e.g.,:

```
$ edge-runtime --eval 'JSON.stringify(Object.getOwnPropertyNames(this))'
```

It's pretty similar to `node --eval`

closes #34