### PR TITLE
Revert "refactor(primitives): use types from urlpattern-polyfill"

### DIFF
--- a/packages/primitives/types/url.d.ts
+++ b/packages/primitives/types/url.d.ts
@@ -1,4 +1,49 @@
-import type { URLPattern } from 'urlpattern-polyfill/dist/types'
+type URLPatternInput = URLPatternInit | string
+
+declare class URLPattern {
+  constructor(init?: URLPatternInput, baseURL?: string)
+  test(input?: URLPatternInput, baseURL?: string): boolean
+  exec(input?: URLPatternInput, baseURL?: string): URLPatternResult | null
+  readonly protocol: string
+  readonly username: string
+  readonly password: string
+  readonly hostname: string
+  readonly port: string
+  readonly pathname: string
+  readonly search: string
+  readonly hash: string
+}
+
+interface URLPatternInit {
+  baseURL?: string
+  username?: string
+  password?: string
+  protocol?: string
+  hostname?: string
+  port?: string
+  pathname?: string
+  search?: string
+  hash?: string
+}
+
+interface URLPatternResult {
+  inputs: [URLPatternInput]
+  protocol: URLPatternComponentResult
+  username: URLPatternComponentResult
+  password: URLPatternComponentResult
+  hostname: URLPatternComponentResult
+  port: URLPatternComponentResult
+  pathname: URLPatternComponentResult
+  search: URLPatternComponentResult
+  hash: URLPatternComponentResult
+}
+
+interface URLPatternComponentResult {
+  input: string
+  groups: {
+    [key: string]: string | undefined
+  }
+}
 
 declare const URLPatternConstructor: typeof URLPattern
 declare const URLConstructor: typeof URL


### PR DESCRIPTION
This reverts commit 3a5f0aa8b6e9e703f2f85dff3290879e99e50688.

# Conflicts:
#	packages/primitives/types/url.d.ts