### PR TITLE
fix(primitives): fetch POST not working due to missing internal

### DIFF
--- a/packages/primitives/src/primitives/fetch.js
+++ b/packages/primitives/src/primitives/fetch.js
@@ -12,10 +12,9 @@ import Agent from 'undici/lib/agent'
 global.AbortController = AbortController
 global.AbortSignal = AbortSignal
 
-// provides a mock to Unidici
-process.nextTick = (callback, ...args) => {
-  setTimeout(callback, 0, ...args)
-}
+// undici uses `process.nextTick`,
+// but process APIs doesn't exist in a runtime context.
+process.nextTick = setImmediate
 
 /**
  * A symbol used to store cookies in the headers module.

--- a/packages/primitives/src/primitives/fetch.js
+++ b/packages/primitives/src/primitives/fetch.js
@@ -12,6 +12,11 @@ import Agent from 'undici/lib/agent'
 global.AbortController = AbortController
 global.AbortSignal = AbortSignal
 
+// provides a mock to Unidici
+process.nextTick = (callback, ...args) => {
+  setTimeout(callback, 0, ...args)
+}
+
 /**
  * A symbol used to store cookies in the headers module.
  */

--- a/packages/primitives/tests/fetch.test.ts
+++ b/packages/primitives/tests/fetch.test.ts
@@ -1,6 +1,34 @@
 import { fetch } from '../fetch'
 import { URL } from '../url'
 
+test('perform a POST as application/json', async () => {
+  const response = await fetch('https://httpbin.org/post', {
+    method: 'POST',
+    body: JSON.stringify({ foo: 'bar' }),
+    headers: {
+      'content-type': 'application/json',
+    },
+  })
+
+  expect(response.status).toEqual(200)
+  const json = await response.json()
+  expect(JSON.parse(json.data).foo).toBe('bar')
+})
+
+test('perform a POST as application/x-www-form-urlencoded', async () => {
+  const response = await fetch('https://httpbin.org/post', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: new URLSearchParams({ foo: 'bar' }),
+  })
+
+  expect(response.status).toEqual(200)
+  const json = await response.json()
+  expect(json.form.foo).toBe('bar')
+})
+
 test('sets header calling Headers constructor', async () => {
   const url = new URL('/about', 'https://vercel.com')
   const response = await fetch(url)


### PR DESCRIPTION
### What's in there?

Unidici [is using process.nextTick()](https://cs.github.com/nodejs/undici?q=nextTick) in many places (along with `process.env` and `process.versions`), but we had no implementation for it.
This led to breaking POST requests. This PR should fix #61.

### How to test?

@Kikobeats added a unit test in this PR to check `POST` requests.
1. build the primitives: `pnpm --filter primitives build`
2. run their tests: `pnpm --filter primitives test`

You can also test it live in the VM:
1. build the whole project: `pnpm build`
2. open node: `node`
3. evaluate a fetch request: 
   ```js
   const { EdgeVM } = require('./packages/vm')
   new EdgeVM().evaluate(`fetch('https://httpbin.org/post', {method: 'POST', body: JSON.stringify({ foo: 'bar' }), headers: {'content-type': 'application/json'}}).then(r => r.json()).then(r => console.log('result', r))`)
   ```
   > you should see something like:
   >
   > result { args: {},
     data: '{"foo":"bar"}',
     files: {},
     form: {},
     headers:
      { Accept: '*/*',
        Accept-Encoding: 'br, gzip, deflate',
        Accept-Language: '*',
        Content-Length: '13',
        Content-Type: 'application/json',
        Host: 'httpbin.org',
        Sec-Fetch-Mode: 'cors',
        User-Agent: 'undici',
        X-Amzn-Trace-Id: 'Root=1-62e7ca36-0cd62dbd75e2523725516a1f' },
     json: { foo: 'bar' },
     url: 'https://httpbin.org/post' }


### Notes to reviewers

We initially thought we could provide a mock when loading the primitive in [the `EdgeVM` class](https://github.com/vercel/edge-runtime/blob/post/packages/vm/src/edge-vm.ts#L162-L192), but the implementation is straightforward and could be done within the primitive.