### PR TITLE
fix: docs example

### DIFF
--- a/docs/pages/packages/runtime.mdx
+++ b/docs/pages/packages/runtime.mdx
@@ -44,7 +44,9 @@ addEventListener('fetch', event => {
 
 const runtime = new EdgeRuntime({ initialCode })
 
-const response = runtime.dispatchFetch('https://example.com')
+const response = await runtime.dispatchFetch(
+  "http://vercel.com?url=https://example.com"
+);
 
 // If your code logic performs asynchronous tasks, you should await them.
 // https://developer.mozilla.org/en-US/docs/Web/API/ExtendableEvent/waitUntil

--- a/docs/pages/packages/runtime.mdx
+++ b/docs/pages/packages/runtime.mdx
@@ -44,9 +44,7 @@ addEventListener('fetch', event => {
 
 const runtime = new EdgeRuntime({ initialCode })
 
-const response = await runtime.dispatchFetch(
-  "http://vercel.com?url=https://example.com"
-);
+const response = await runtime.dispatchFetch('http://vercel.com?url=https://example.com')
 
 // If your code logic performs asynchronous tasks, you should await them.
 // https://developer.mozilla.org/en-US/docs/Web/API/ExtendableEvent/waitUntil


### PR DESCRIPTION
The url parsing logic in `initialCode` tries to extract a url from the `searchParams`. Also, there's an `await` missing.