### PR TITLE
fix(repl,format): fix repl & formatter issues

### DIFF
--- a/packages/format/src/index.ts
+++ b/packages/format/src/index.ts
@@ -144,7 +144,7 @@ export function createFormat(opts: FormatterOptions = {}) {
       ? ['[', ']']
       : isValueFunction
       ? ['', '']
-      : ['{', '}']
+      : [`${getConstructorName(value)} {`.trim(), '}']
 
     if (keys.length === 0 && (!isValueArray || value.length === 0)) {
       return braces[0] + base + braces[1]
@@ -407,4 +407,13 @@ function makeCircularReplacer() {
     }
     return value
   }
+}
+
+function getConstructorName(value: unknown): string {
+  if (typeof value !== 'object' || !value) {
+    return ''
+  }
+  const constructor = value.constructor.name
+  if (constructor === 'Object') return ''
+  return constructor
 }

--- a/packages/format/tests/index.test.ts
+++ b/packages/format/tests/index.test.ts
@@ -2,6 +2,13 @@ import { createFormat } from '../dist'
 
 const format = createFormat()
 
+it('formats class instances', () => {
+  class MyClass {
+    constructor(public runtime: string) {}
+  }
+  expect(format(new MyClass('Edge'))).toBe(`MyClass { runtime: 'Edge' }`)
+})
+
 it('first argument', () => {
   expect(format()).toBe('')
   expect(format('')).toBe('')
@@ -94,7 +101,7 @@ it('string (%s)', () => {
       readonly name = 'CustomError'
     }
     expect(format(new CustomError('bar'))).toBe(
-      "{ [CustomError: bar] name: 'CustomError' }"
+      "CustomError { [CustomError: bar] name: 'CustomError' }"
     )
   })()
 })
@@ -153,7 +160,7 @@ it('object (%o)', () => {
     const error = new Error('mock error')
     delete error.stack
     expect(format('%o', error)).toBe(
-      "{ [Error: mock error] message: 'mock error' }"
+      "Error { [Error: mock error] message: 'mock error' }"
     )
   })()
 

--- a/packages/runtime/src/cli/repl.ts
+++ b/packages/runtime/src/cli/repl.ts
@@ -9,25 +9,17 @@ const writer: createRepl.REPLWriter = (output) => {
   return typeof output === 'function' ? output.toString() : format(output)
 }
 
-const repl = createRepl.start({ prompt: 'ƒ => ', writer })
-
-Object.getOwnPropertyNames(repl.context).forEach(
-  (mod) => delete repl.context[mod]
-)
-
 const runtime = new EdgeRuntime()
-
-Object.getOwnPropertyNames(runtime.context)
-  .filter((key) => !key.startsWith('__'))
-  .forEach((key) =>
-    Object.assign(repl.context, { [key]: runtime.context[key] })
-  )
-
-Object.defineProperty(repl.context, 'EdgeRuntime', {
-  configurable: false,
-  enumerable: false,
-  writable: false,
-  value: runtime.context.EdgeRuntime,
+const repl = createRepl.start({
+  prompt: 'ƒ => ',
+  writer,
+  async eval(cmd, _context, _file, cb) {
+    try {
+      cb(null, runtime.evaluate(cmd))
+    } catch (err: any) {
+      cb(err, null)
+    }
+  },
 })
 
 const nodeMajorVersion = parseInt(process.versions.node.split('.')[0])


### PR DESCRIPTION
This PR introduces the following changes:

- fix(cli): make repl execute all commands in the edge vm instead of copying the values
- fix(format): include constructor name in the logger

Unfortunately, there an open question that makes this PR to be kept in draft state until we resolve it: when not passing an evaluator, seems like the user code gets executed in a context that allows top-level await. This PR disables it because the code gets evaluated in a `vm` context that does not allow it, and `vm.Module` is [still experimental](https://nodejs.org/docs/latest-v16.x/api/vm.html#class-vmmodule).

We need to decide whether we still want to support it, and if we do, we need to add a test for it to make sure we do support it in this PR somehow.

See

* `vm` module not allowing top level await: https://github.com/nodejs/node/issues/40898