### PR TITLE
docs: fixes invalid links to polyfills

### DIFF
--- a/docs/pages/features/polyfills.mdx
+++ b/docs/pages/features/polyfills.mdx
@@ -6,19 +6,18 @@ If you are using an old Node.js version, then it is likely one of these Web APIs
 
 Under the hood, the following Web APIs are used by the **Edge Runtime**:
 
-| polyfill                                                             | node12 | node14 | node16 | node18 |
-| -------------------------------------------------------------------- | ------ | ------ | ------ | ------ |
-| [http](/packages/primitives/src/polyfills/http.js)                   | x      |        |        |        |
-| [util.types](/packages/primitives/src/polyfills/util-types.js#L5)    | x      |        |        |        |
-| [buffer](/packages/primitives/src/index.js#L26)                      | x      |        |        |        |
-| [WebCrypto](/packages/primitives/src/index.js#L31)                   | x      | x      |        |        |
-| [AbortController, AbortSignal](/packages/primitives/src/index.js#L9) | x      | x      |        |        |
-| [AggregateError](/packages/primitives/src/index.js#L15)              | x      | x      |        |        |
-| [base64](/packages/primitives/src/index.js#L20)                      | x      | x      |        |        |
-| [fetch, Request, Response](/packages/primitives/src/index.js#L39)    | x      | x      | x      |        |
-| [URLPattern](/packages/primitives/src/index.js#L69)                  | x      | x      | x      | x      |
-| [Cache](/packages/primitives/src/index.js#L49)                    | x      | x      | x      | x      |
-| [WebStreams](/packages/primitives/src/index.js#L56)                  | x      | x      | x      | x      |
+| polyfill                                                                                                                                | node12 | node14 | node16 | node18 |
+| --------------------------------------------------------------------------------------------------------------------------------------- | ------ | ------ | ------ | ------ |
+| [http](https://github.com/vercel/edge-runtime/blob/main/packages/primitives/src/patches/http.js)                                        | x      |        |        |        |
+| [util.types](https://github.com/vercel/edge-runtime/blob/main/packages/primitives/src/patches/util-types.js)                            | x      |        |        |        |
+| [buffer](https://github.com/vercel/edge-runtime/blob/main/packages/primitives/src/patches/buffer.js)                                    | x      |        |        |        |
+| [WebCrypto](https://github.com/vercel/edge-runtime/blob/main/packages/primitives/src/primitives/crypto.js)                              | x      | x      |        |        |
+| [AbortController, AbortSignal](https://github.com/vercel/edge-runtime/blob/main/packages/primitives/src/primitives/abort-controller.js) | x      | x      |        |        |
+| [base64](https://github.com/vercel/edge-runtime/blob/main/packages/primitives/src/primitives/encoding.js)                               | x      | x      |        |        |
+| [fetch, Request, Response](https://github.com/vercel/edge-runtime/blob/main/packages/primitives/src/primitives/fetch.js)                | x      | x      | x      |        |
+| [URLPattern](https://github.com/vercel/edge-runtime/blob/main/packages/primitives/src/primitives/url.js)                                | x      | x      | x      | x      |
+| [Cache](https://github.com/vercel/edge-runtime/blob/main/packages/primitives/src/primitives/cache.js)                                   | x      | x      | x      | x      |
+| [WebStreams](https://github.com/vercel/edge-runtime/blob/main/packages/primitives/src/primitives/streams.js)                            | x      | x      | x      | x      |
 
 The Edge Runtime polyfills missing APIs for backward compatibility with older Node.js versions.
 


### PR DESCRIPTION
### What's in there?

Our links to polyfills got broken when we refactored them to fix `instanceof` operator.

### How to test?

On the [preview url](https://edge-runtime-git-docs-polyfills-links.vercel.sh/features/polyfills)

### Note to reviewers

I'm not too sure about AggregateError. I couldn't found where we polyfill it (assuming we still do).
I'm also not very sure about how the information is presented on the page.

<img width="647" alt="image" src="https://user-images.githubusercontent.com/186268/182651833-ccac6006-5346-4107-9b49-c8d70ca522f2.png">

It's not very clear to me what happens:
1. is the runtime using http module when running on Node@12 only? what does it use when running on Node@14+?
2. is the runtime loading an http polyfill for Node@12 only? does it rely on node builtin when running on Node@14+?

I'd like we clarify this, but before I need your guidance in understanding it better.
