### PR TITLE
feat: add @edge-runtime/user-agent for user agent parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,18 @@
       "email": "javier.velasco86@gmail.com"
     },
     {
+      "name": "Gal Schlezinger",
+      "email": "gal@spitfire.co.il"
+    },
+    {
+      "name": "feugy",
+      "email": "damien@vercel.com"
+    },
+    {
+      "name": "Balázs Orbán",
+      "email": "info@balazsorban.com"
+    },
+    {
       "name": "Lee Robinson",
       "email": "me@leerob.io"
     },
@@ -24,12 +36,8 @@
       "email": "yixuanxu94@outlook.com"
     },
     {
-      "name": "feugy",
-      "email": "damien@vercel.com"
-    },
-    {
-      "name": "Gal Schlezinger",
-      "email": "gal@spitfire.co.il"
+      "name": "Jan Potoms",
+      "email": "2109932+Janpot@users.noreply.github.com"
     },
     {
       "name": "Ian Mitchell",

--- a/packages/user-agent/package.json
+++ b/packages/user-agent/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@edge-runtime/user-agent",
+  "version": "0.0.0",
+  "description": "An Edge Runtime compatible user agent parsing utility",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "test": "jest",
+    "build": "tsup"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@edge-runtime/jest-environment": "workspace:1.1.0-beta.26",
+    "@types/ua-parser-js": "0.7.36",
+    "ts-jest": "28.0.3",
+    "tsup": "6",
+    "ua-parser-js": "1.0.2"
+  },
+  "files": ["dist"],
+  "jest": {
+    "globals": {
+      "ts-jest": {
+        "diagnostics": true,
+        "isolatedModules": true
+      }
+    },
+    "preset": "ts-jest/presets/default",
+    "testEnvironment": "node",
+    "testTimeout": 30000
+  }
+}

--- a/packages/user-agent/package.json
+++ b/packages/user-agent/package.json
@@ -19,7 +19,9 @@
     "tsup": "6",
     "ua-parser-js": "1.0.2"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "jest": {
     "globals": {
       "ts-jest": {
@@ -28,7 +30,6 @@
       }
     },
     "preset": "ts-jest/presets/default",
-    "testEnvironment": "node",
-    "testTimeout": 30000
+    "testEnvironment": "@edge-runtime/jest-environment"
   }
 }

--- a/packages/user-agent/package.json
+++ b/packages/user-agent/package.json
@@ -11,7 +11,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MPLv2",
   "devDependencies": {
     "@edge-runtime/jest-environment": "workspace:1.1.0-beta.26",
     "@types/ua-parser-js": "0.7.36",

--- a/packages/user-agent/src/index.ts
+++ b/packages/user-agent/src/index.ts
@@ -1,0 +1,44 @@
+import parseua from 'ua-parser-js'
+
+export interface UserAgent {
+  isBot: boolean
+  ua: string
+  browser: {
+    name?: string
+    version?: string
+  }
+  device: {
+    model?: string
+    type?: string
+    vendor?: string
+  }
+  engine: {
+    name?: string
+    version?: string
+  }
+  os: {
+    name?: string
+    version?: string
+  }
+  cpu: {
+    architecture?: string
+  }
+}
+
+export function isBot(input: string): boolean {
+  return /Googlebot|Mediapartners-Google|AdsBot-Google|googleweblight|Storebot-Google|Google-PageRenderer|Bingbot|BingPreview|Slurp|DuckDuckBot|baiduspider|yandex|sogou|LinkedInBot|bitlybot|tumblr|vkShare|quora link preview|facebookexternalhit|facebookcatalog|Twitterbot|applebot|redditbot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|ia_archiver/i.test(
+    input
+  )
+}
+
+export function userAgentFromString(input: string | undefined): UserAgent {
+  return {
+    ...parseua(input),
+    isBot: input === undefined ? false : isBot(input),
+  }
+}
+
+type HeaderLike = { get(key: string): string | null | undefined }
+export function userAgent({ headers }: { headers: HeaderLike }): UserAgent {
+  return userAgentFromString(headers.get('user-agent') || undefined)
+}

--- a/packages/user-agent/src/index.ts
+++ b/packages/user-agent/src/index.ts
@@ -39,6 +39,6 @@ export function userAgentFromString(input: string | undefined): UserAgent {
 }
 
 type HeaderLike = { get(key: string): string | null | undefined }
-export function userAgent({ headers }: { headers: HeaderLike }): UserAgent {
-  return userAgentFromString(headers.get('user-agent') || undefined)
+export function userAgent(request?: { headers: HeaderLike }): UserAgent {
+  return userAgentFromString(request?.headers?.get('user-agent') || undefined)
 }

--- a/packages/user-agent/test/index.test.ts
+++ b/packages/user-agent/test/index.test.ts
@@ -4,29 +4,85 @@
 
 import { userAgent, userAgentFromString } from '../src'
 
-test('userAgent accepts a request', () => {
-  const request = new Request('https://example.vercel.sh', {
-    headers: {
-      'User-Agent':
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36',
-    },
+const emptyParsedUA = {
+  browser: {},
+  cpu: {},
+  device: {},
+  engine: {},
+  isBot: false,
+  os: {},
+  ua: '',
+}
+
+describe('userAgent()', () => {
+  it('accepts a request', () => {
+    const request = new Request('https://example.vercel.sh', {
+      headers: {
+        'User-Agent':
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36',
+      },
+    })
+    const ua = userAgent(request)
+    expect(ua.browser).toMatchObject({
+      name: 'Chrome',
+      version: '83.0.4103.116',
+    })
   })
-  const ua = userAgent(request)
-  expect(ua.browser).toMatchObject({
-    name: 'Chrome',
-    version: '83.0.4103.116',
+
+  it('handles no input', () => {
+    expect(userAgent()).toEqual(emptyParsedUA)
+  })
+
+  it('handles no user-agent header', () => {
+    expect(userAgent(new Request('https://example.vercel.sh'))).toEqual(
+      emptyParsedUA
+    )
   })
 })
 
-test('userAgentFromString can receive a nil value', () => {
-  const ua = userAgentFromString(undefined)
-  expect(ua).toEqual({
-    browser: {},
-    cpu: {},
-    device: {},
-    engine: {},
-    isBot: false,
-    os: {},
-    ua: '',
+describe('userAgentFromString()', () => {
+  it('can receive a nil value', () => {
+    expect(userAgentFromString(undefined)).toEqual(emptyParsedUA)
+  })
+
+  it('parses regular user-agent', () => {
+    const source =
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36'
+    expect(userAgentFromString(source)).toMatchObject({
+      browser: {
+        major: '83',
+        name: 'Chrome',
+        version: '83.0.4103.116',
+      },
+      cpu: { architecture: 'amd64' },
+      engine: {
+        name: 'Blink',
+        version: '83.0.4103.116',
+      },
+      isBot: false,
+      os: {
+        name: 'Windows',
+        version: '10',
+      },
+      ua: source,
+    })
+  })
+
+  it('detects bots', () => {
+    const source =
+      'Mozilla/5.0 (Linux; Android 5.0; SM-G920A) AppleWebKit (KHTML, like Gecko) Chrome Mobile Safari (compatible; AdsBot-Google-Mobile; +http://www.google.com/mobile/adsbot.html)'
+    expect(userAgentFromString(source)).toMatchObject({
+      device: {
+        model: 'SM-G920A',
+        type: 'mobile',
+        vendor: 'Samsung',
+      },
+      isBot: true,
+      os: {
+        name: 'Android',
+        version: '5.0',
+      },
+      ua: source,
+    })
   })
 })

--- a/packages/user-agent/test/index.test.ts
+++ b/packages/user-agent/test/index.test.ts
@@ -1,7 +1,3 @@
-/**
- * @jest-environment @edge-runtime/jest-environment
- */
-
 import { userAgent, userAgentFromString } from '../src'
 
 const emptyParsedUA = {

--- a/packages/user-agent/test/index.test.ts
+++ b/packages/user-agent/test/index.test.ts
@@ -1,0 +1,32 @@
+/**
+ * @jest-environment @edge-runtime/jest-environment
+ */
+
+import { userAgent, userAgentFromString } from '../src'
+
+test('userAgent accepts a request', () => {
+  const request = new Request('https://example.vercel.sh', {
+    headers: {
+      'User-Agent':
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36',
+    },
+  })
+  const ua = userAgent(request)
+  expect(ua.browser).toMatchObject({
+    name: 'Chrome',
+    version: '83.0.4103.116',
+  })
+})
+
+test('userAgentFromString can receive a nil value', () => {
+  const ua = userAgentFromString(undefined)
+  expect(ua).toEqual({
+    browser: {},
+    cpu: {},
+    device: {},
+    engine: {},
+    isBot: false,
+    os: {},
+    ua: '',
+  })
+})

--- a/packages/user-agent/tsup.config.ts
+++ b/packages/user-agent/tsup.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['./src/index.ts'],
+  dts: true,
+  format: ['cjs', 'esm'],
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,6 +157,20 @@ importers:
     dependencies:
       '@edge-runtime/primitives': link:../primitives
 
+  packages/user-agent:
+    specifiers:
+      '@edge-runtime/jest-environment': workspace:1.1.0-beta.26
+      '@types/ua-parser-js': 0.7.36
+      ts-jest: 28.0.3
+      tsup: '6'
+      ua-parser-js: 1.0.2
+    devDependencies:
+      '@edge-runtime/jest-environment': link:../jest-environment
+      '@types/ua-parser-js': 0.7.36
+      ts-jest: 28.0.3
+      tsup: 6.0.1
+      ua-parser-js: 1.0.2
+
   packages/vm:
     specifiers:
       '@edge-runtime/primitives': ^1.1.0-beta.25
@@ -1884,6 +1898,10 @@ packages:
 
   /@types/stack-utils/2.0.1:
     resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
+
+  /@types/ua-parser-js/0.7.36:
+    resolution: {integrity: sha512-N1rW+njavs70y2cApeIw1vLMYXRwfBy+7trgavGuuTfOd7j1Yh7QTRc/yqsPl6ncokt72ZXuxEU0PiCp9bSwNQ==}
+    dev: true
 
   /@types/unist/2.0.6:
     resolution: {integrity: sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==}
@@ -8523,7 +8541,7 @@ packages:
     dev: true
 
   /tr46/1.0.1:
-    resolution: {integrity: sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=}
+    resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
     dependencies:
       punycode: 2.1.1
     dev: true
@@ -8556,6 +8574,37 @@ packages:
 
   /ts-interface-checker/0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+    dev: true
+
+  /ts-jest/28.0.3:
+    resolution: {integrity: sha512-HzgbEDQ2KgVtDmpXToqAcKTyGHdHsG23i/iUjfxji92G5eT09S1m9UHZd7csF0Bfgh9txM4JzwHnv7r1waFPlw==}
+    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@types/jest': ^27.0.0
+      babel-jest: ^28.0.0
+      esbuild: '*'
+      jest: ^28.0.0
+      typescript: '>=4.3'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@types/jest':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      jest-util: 28.1.3
+      json5: 2.2.1
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.3.7
+      yargs-parser: 20.2.9
     dev: true
 
   /ts-jest/28.0.3_vxl67t2ufryzmzuw4lrmj2eedq:
@@ -8888,6 +8937,10 @@ packages:
     resolution: {integrity: sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==}
     engines: {node: '>=4.2.0'}
     hasBin: true
+    dev: true
+
+  /ua-parser-js/1.0.2:
+    resolution: {integrity: sha512-00y/AXhx0/SsnI51fTc0rLRmafiGOM4/O+ny10Ps7f+j/b8p/ZY11ytMgznXkOVo4GQ+KwQG5UQLkLGirsACRg==}
     dev: true
 
   /uglify-js/3.15.5:


### PR DESCRIPTION
This PR introduces `@edge-runtime/user-agent` package.

This is a very small library that is extracted from Next.js to allow all frameworks to integrate the user agent parsing logic. It's not a lot, but should be helpful nevertheless.
