### PR TITLE
refactor(vm): remove `ArrayBuffer` global

### DIFF
--- a/packages/vm/src/edge-vm.ts
+++ b/packages/vm/src/edge-vm.ts
@@ -105,7 +105,7 @@ function addPrimitives(context: VMContext) {
   const encodings = requireWithCache({
     context,
     path: require.resolve('@edge-runtime/primitives/encoding'),
-    scopedContext: { Buffer, global: { ArrayBuffer } },
+    scopedContext: { Buffer, global: {} },
   })
 
   // Encoding APIs


### PR DESCRIPTION
Removes unrequired exposure of `ArrayBuffer` as a `global` for `encoding` module.