### PR TITLE
chore(devDeps): bump undici to 5.10.0

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,8 +1,10 @@
 import type { Config } from '@jest/types'
+import path from 'path'
 
 export default (rootDir: string): Config.InitialOptions => {
   return {
     rootDir,
+    setupFilesAfterEnv: [path.join(__dirname, 'jest.setup.js')],
     globals: {
       'ts-jest': {
         'diagnostics': true,

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+global.AbortSignal = require('./packages/primitives/dist/abort-controller').AbortSignal

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -33,7 +33,7 @@
     "formdata-node": "4.4.1",
     "text-encoding": "0.7.0",
     "tsup": "6",
-    "undici": "5.5.1",
+    "undici": "5.10.0",
     "urlpattern-polyfill": "5.0.9",
     "uuid": "9.0.0",
     "web-streams-polyfill": "4.0.0-beta.3",

--- a/packages/primitives/src/patches/undici-core-request.js
+++ b/packages/primitives/src/patches/undici-core-request.js
@@ -1,4 +1,4 @@
-// Copied from https://github.com/nodejs/undici/blob/v5.5.1/lib/core/request.js
+// Copied from https://github.com/nodejs/undici/blob/v5.10.0/lib/core/request.js
 // modified to allow any headers
 
 'use strict'

--- a/packages/primitives/src/primitives/fetch.js
+++ b/packages/primitives/src/primitives/fetch.js
@@ -168,7 +168,6 @@ function normalizeAndValidateHeaderValue(potentialValue, errorPrefix) {
 }
 
 /**
->>>>>>> Stashed changes
  * A global agent to be used with every fetch request. We also define a
  * couple of globals that we can hide in the runtime for advanced use.
  */

--- a/packages/primitives/src/primitives/fetch.js
+++ b/packages/primitives/src/primitives/fetch.js
@@ -5,6 +5,9 @@ import * as CoreSymbols from 'undici/lib/core/symbols'
 import * as FetchSymbols from 'undici/lib/fetch/symbols'
 import * as HeadersModule from 'undici/lib/fetch/headers'
 import * as ResponseModule from 'undici/lib/fetch/response'
+import * as UtilModule from 'undici/lib/fetch/util'
+// Import WebIDLModule to generate corresponding spec defined errors
+import * as WebIDLModule from 'undici/lib/fetch/webidl'
 
 import fetchImpl from 'undici/lib/fetch'
 import Agent from 'undici/lib/agent'
@@ -37,11 +40,9 @@ HeadersModule.HeadersList.prototype.append = function (name, value) {
     })
   }
 
-  const _name = HeadersModule.normalizeAndValidateHeaderName(name)
+  const _name = normalizeAndValidateHeaderValue(name, 'Header.append')
   if (_name === 'set-cookie') {
-    this[SCookies].push(
-      HeadersModule.normalizeAndValidateHeaderValue(_name, value)
-    )
+    this[SCookies].push(normalizeAndValidateHeaderValue(value, 'Header.append'))
   }
 
   return result
@@ -63,11 +64,9 @@ HeadersModule.HeadersList.prototype.set = function (name, value) {
     })
   }
 
-  const _name = HeadersModule.normalizeAndValidateHeaderName(name)
+  const _name = normalizeAndValidateHeaderName(name)
   if (_name === 'set-cookie') {
-    this[SCookies] = [
-      HeadersModule.normalizeAndValidateHeaderValue(_name, value),
-    ]
+    this[SCookies] = [normalizeAndValidateHeaderValue(value, 'HeadersList.set')]
   }
 
   return result
@@ -89,7 +88,7 @@ HeadersModule.HeadersList.prototype.delete = function (name) {
     })
   }
 
-  const _name = HeadersModule.normalizeAndValidateHeaderName(name)
+  const _name = normalizeAndValidateHeaderName(name, 'Headers.delete')
   if (_name === 'set-cookie') {
     this[SCookies] = []
   }
@@ -101,7 +100,7 @@ HeadersModule.HeadersList.prototype.delete = function (name) {
  * headers.
  */
 HeadersModule.Headers.prototype.getAll = function (name) {
-  const _name = HeadersModule.normalizeAndValidateHeaderName(name)
+  const _name = normalizeAndValidateHeaderName(name, 'Headers.getAll')
   if (_name !== 'set-cookie') {
     throw new Error(`getAll can only be used with 'set-cookie'`)
   }
@@ -118,6 +117,55 @@ ResponseModule.Response.error = function (...args) {
   const response = __error.call(this, ...args)
   response[FetchSymbols.kHeaders][FetchSymbols.kGuard] = 'response'
   return response
+}
+
+/**
+ * normalize header name per WHATWG spec, and validate
+ *
+ * @param {string} potentialName
+ * @param {'Header.append' | 'Headers.delete' | 'Headers.get' | 'Headers.has' | 'Header.set'} errorPrefix
+ */
+function normalizeAndValidateHeaderName(potentialName, errorPrefix) {
+  const normalizedName = potentialName.toLowerCase()
+
+  if (UtilModule.isValidHeaderName(normalizedName)) {
+    return normalizedName
+  }
+
+  // Generate an WHATWG fetch spec compliant error
+  WebIDLModule.errors.invalidArgument({
+    prefix: errorPrefix,
+    value: normalizedName,
+    type: 'header name',
+  })
+}
+
+/**
+ * normalize header value per WHATWG spec, and validate
+ *
+ * @param {string} potentialValue
+ * @param {'Header.append' | 'Header.set'} errorPrefix
+ */
+function normalizeAndValidateHeaderValue(potentialValue, errorPrefix) {
+  /**
+   * To normalize a byte sequence potentialValue, remove
+   * any leading and trailing HTTP whitespace bytes from
+   *  potentialValue.
+   *
+   * See https://fetch.spec.whatwg.org/#concept-header-value-normalize
+   */
+  const normalizedValue = potentialValue.replace(/^[\r\n\t ]+|[\r\n\t ]+$/g, '')
+
+  if (UtilModule.isValidHeaderValue(normalizedValue)) {
+    return normalizedValue
+  }
+
+  // Generate an WHATWG fetch spec compliant error
+  WebIDLModule.errors.invalidArgument({
+    prefix: errorPrefix,
+    value: normalizedValue,
+    type: 'header value',
+  })
 }
 
 /**

--- a/packages/primitives/src/primitives/fetch.js
+++ b/packages/primitives/src/primitives/fetch.js
@@ -6,7 +6,6 @@ import * as FetchSymbols from 'undici/lib/fetch/symbols'
 import * as HeadersModule from 'undici/lib/fetch/headers'
 import * as ResponseModule from 'undici/lib/fetch/response'
 import * as UtilModule from 'undici/lib/fetch/util'
-// Import WebIDLModule to generate corresponding spec defined errors
 import * as WebIDLModule from 'undici/lib/fetch/webidl'
 
 import fetchImpl from 'undici/lib/fetch'
@@ -169,6 +168,7 @@ function normalizeAndValidateHeaderValue(potentialValue, errorPrefix) {
 }
 
 /**
+>>>>>>> Stashed changes
  * A global agent to be used with every fetch request. We also define a
  * couple of globals that we can hide in the runtime for advanced use.
  */

--- a/packages/primitives/tests/abort-controller.test.ts
+++ b/packages/primitives/tests/abort-controller.test.ts
@@ -12,7 +12,7 @@ describe('AbortController', () => {
         signal: controller.signal,
       })
     } catch (error: any) {
-      expect(error.message).toEqual('The operation was aborted')
+      expect(error.message).toEqual('The operation was aborted.')
     }
   })
 

--- a/packages/primitives/tests/encoding.test.ts
+++ b/packages/primitives/tests/encoding.test.ts
@@ -10,3 +10,15 @@ test('TextDecoder', () => {
   const output = utf8Decoder.decode(input)
   expect(output).toBe('edge-ping.vercel.app')
 })
+
+test('TextDecoder with stream', () => {
+  const input = new Uint8Array([
+    123, 34, 103, 114, 101, 101, 116, 105, 110, 103, 34, 58, 34, 104, 101, 108,
+    108, 111, 34, 125,
+  ])
+
+  const textDecoder = new TextDecoder()
+  let result = textDecoder.decode(input, { stream: true })
+
+  expect(result).toBe('{"greeting":"hello"}')
+})

--- a/packages/primitives/tests/request.test.ts
+++ b/packages/primitives/tests/request.test.ts
@@ -14,3 +14,14 @@ test('combine with Headers', async () => {
   })
   expect(request.headers.get('cookie')).toBe('hello=world')
 })
+
+test('serialize body into JSON', async () => {
+  const obj = { hello: 'world' }
+  const request = new Request('https://example.vercel.sh', {
+    method: 'POST',
+    body: JSON.stringify(obj),
+  })
+
+  const data = await request.json()
+  expect(data).toEqual(obj)
+})

--- a/packages/runtime/src/server/create-handler.ts
+++ b/packages/runtime/src/server/create-handler.ts
@@ -34,7 +34,11 @@ export function createHandler<T extends EdgeContext>(options: Options<T>) {
 
       const body =
         req.method !== 'GET' && req.method !== 'HEAD'
-          ? getClonableBodyStream(req, options.runtime.context.TransformStream)
+          ? getClonableBodyStream(
+              req,
+              options.runtime.evaluate('Uint8Array'),
+              options.runtime.context.TransformStream
+            )
           : undefined
 
       const response = await options.runtime.dispatchFetch(

--- a/packages/vm/src/edge-vm.ts
+++ b/packages/vm/src/edge-vm.ts
@@ -192,9 +192,6 @@ function addPrimitives(context: VMContext) {
     scopedContext: {
       Uint8Array: createUint8ArrayForContext(context),
       Buffer,
-      FinalizationRegistry: function () {
-        return { register: function () {} }
-      },
       global: {},
       queueMicrotask,
       setImmediate,

--- a/packages/vm/src/edge-vm.ts
+++ b/packages/vm/src/edge-vm.ts
@@ -198,6 +198,7 @@ function addPrimitives(context: VMContext) {
       global: {},
       queueMicrotask,
       setImmediate,
+      clearImmediate,
     },
   })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,7 +132,7 @@ importers:
       formdata-node: 4.4.1
       text-encoding: 0.7.0
       tsup: '6'
-      undici: 5.5.1
+      undici: 5.10.0
       urlpattern-polyfill: 5.0.9
       uuid: 9.0.0
       web-streams-polyfill: 4.0.0-beta.3
@@ -149,7 +149,7 @@ importers:
       formdata-node: 4.4.1
       text-encoding: 0.7.0
       tsup: 6.2.2
-      undici: 5.5.1
+      undici: 5.10.0
       urlpattern-polyfill: 5.0.9
       uuid: 9.0.0
       web-streams-polyfill: 4.0.0-beta.3
@@ -7202,8 +7202,8 @@ packages:
     resolution: {integrity: sha512-z4o1fvKUojIWh9XuaVLUDdf86RQiq13AC1dmHbTpoyuu+bquHms76v16CjycCbec87J7z0k//SiQVk0sMdFmpQ==}
     dev: true
 
-  /undici/5.5.1:
-    resolution: {integrity: sha512-MEvryPLf18HvlCbLSzCW0U00IMftKGI5udnjrQbC5D4P0Hodwffhv+iGfWuJwg16Y/TK11ZFK8i+BPVW2z/eAw==}
+  /undici/5.10.0:
+    resolution: {integrity: sha512-c8HsD3IbwmjjbLvoZuRI26TZic+TSEe8FPMLLOkN1AfYRhdjnKBU6yL+IwcSCbdZiX4e5t0lfMDLDCqj4Sq70g==}
     engines: {node: '>=12.18'}
     dev: true
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,25 +5,25 @@ importers:
   .:
     specifiers:
       '@changesets/cli': latest
-      '@jest/types': latest
+      '@jest/types': 28.1.3
       '@svitejs/changesets-changelog-github-compact': latest
       '@types/jest': latest
       '@types/node': '12'
       c8: latest
       finepack: latest
       git-authors-cli: latest
-      jest: latest
+      jest: 28.1.3
       jest-watch-typeahead: latest
       nano-staged: latest
       prettier: latest
       simple-git-hooks: latest
-      ts-jest: latest
+      ts-jest: 28.0.8
       ts-node: latest
       turbo: latest
       typescript: latest
     devDependencies:
       '@changesets/cli': 2.24.3
-      '@jest/types': 29.0.2
+      '@jest/types': 28.1.3
       '@svitejs/changesets-changelog-github-compact': 0.1.1
       '@types/jest': 28.1.7
       '@types/node': 12.20.55
@@ -35,7 +35,7 @@ importers:
       nano-staged: 0.8.0
       prettier: 2.7.1
       simple-git-hooks: 2.8.0
-      ts-jest: 28.0.8_csltoo4z63p2ffsse3qn3hzmuu
+      ts-jest: 28.0.8_lhw3xkmzugq5tscs3x2ndm4sby
       ts-node: 10.9.1_rf36vhyq5bw7w55ijgrvnfasgy
       turbo: 1.4.3
       typescript: 4.7.4
@@ -930,13 +930,6 @@ packages:
     dependencies:
       '@sinclair/typebox': 0.24.28
 
-  /@jest/schemas/29.0.0:
-    resolution: {integrity: sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@sinclair/typebox': 0.24.28
-    dev: true
-
   /@jest/source-map/28.1.2:
     resolution: {integrity: sha512-cV8Lx3BeStJb8ipPHnqVw/IM2VCMWO3crWZzYodSIkxXnRcXJipCdx1JCK0K5MsJJouZQTH73mzf4vgxRaH9ww==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
@@ -996,21 +989,9 @@ packages:
       '@jest/schemas': 28.1.3
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 18.7.14
-      '@types/yargs': 17.0.11
-      chalk: 4.1.2
-
-  /@jest/types/29.0.2:
-    resolution: {integrity: sha512-5WNMesBLmlkt1+fVkoCjHa0X3i3q8zc4QLTDkdHgCa2gyPZc7rdlZBWgVLqwS1860ZW5xJuCDwAzqbGaXIr/ew==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@jest/schemas': 29.0.0
-      '@types/istanbul-lib-coverage': 2.0.4
-      '@types/istanbul-reports': 3.0.1
       '@types/node': 12.20.55
       '@types/yargs': 17.0.11
       chalk: 4.1.2
-    dev: true
 
   /@jridgewell/gen-mapping/0.1.1:
     resolution: {integrity: sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==}
@@ -1604,7 +1585,6 @@ packages:
 
   /@types/node/12.20.55:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
-    dev: true
 
   /@types/node/18.7.14:
     resolution: {integrity: sha512-6bbDaETVi8oyIARulOE9qF1/Qdi/23z6emrUh0fNJRUmjznqrixD4MpGDdgOFk5Xb0m2H6Xu42JGdvAxaJR/wA==}
@@ -6879,7 +6859,7 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /ts-jest/28.0.8_csltoo4z63p2ffsse3qn3hzmuu:
+  /ts-jest/28.0.8_lhw3xkmzugq5tscs3x2ndm4sby:
     resolution: {integrity: sha512-5FaG0lXmRPzApix8oFG8RKjAz4ehtm8yMKOTy5HX3fY6W8kmvOrmcY0hKDElW52FJov+clhUbrKAqofnj4mXTg==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     hasBin: true
@@ -6900,7 +6880,7 @@ packages:
       esbuild:
         optional: true
     dependencies:
-      '@jest/types': 29.0.2
+      '@jest/types': 28.1.3
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       jest: 28.1.3_ul4bw7p6zpcbqc5ta2hjpidvwy

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,25 +5,25 @@ importers:
   .:
     specifiers:
       '@changesets/cli': latest
-      '@jest/types': 28.1.3
+      '@jest/types': latest
       '@svitejs/changesets-changelog-github-compact': latest
       '@types/jest': latest
       '@types/node': '12'
       c8: latest
       finepack: latest
       git-authors-cli: latest
-      jest: 28.1.3
+      jest: latest
       jest-watch-typeahead: latest
       nano-staged: latest
       prettier: latest
       simple-git-hooks: latest
-      ts-jest: 28.0.8
+      ts-jest: latest
       ts-node: latest
       turbo: latest
       typescript: latest
     devDependencies:
       '@changesets/cli': 2.24.3
-      '@jest/types': 28.1.3
+      '@jest/types': 29.0.2
       '@svitejs/changesets-changelog-github-compact': 0.1.1
       '@types/jest': 28.1.7
       '@types/node': 12.20.55
@@ -35,7 +35,7 @@ importers:
       nano-staged: 0.8.0
       prettier: 2.7.1
       simple-git-hooks: 2.8.0
-      ts-jest: 28.0.8_lhw3xkmzugq5tscs3x2ndm4sby
+      ts-jest: 28.0.8_csltoo4z63p2ffsse3qn3hzmuu
       ts-node: 10.9.1_rf36vhyq5bw7w55ijgrvnfasgy
       turbo: 1.4.3
       typescript: 4.7.4
@@ -788,7 +788,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/types': 28.1.3
-      '@types/node': 18.7.8
+      '@types/node': 12.20.55
       chalk: 4.1.2
       jest-message-util: 28.1.3
       jest-util: 28.1.3
@@ -809,14 +809,14 @@ packages:
       '@jest/test-result': 28.1.3
       '@jest/transform': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 18.7.8
+      '@types/node': 12.20.55
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.3.2
       exit: 0.1.2
       graceful-fs: 4.2.10
       jest-changed-files: 28.1.3
-      jest-config: 28.1.3_famynuxl7vhnyacjiboum65kqi
+      jest-config: 28.1.3_ul4bw7p6zpcbqc5ta2hjpidvwy
       jest-haste-map: 28.1.3
       jest-message-util: 28.1.3
       jest-regex-util: 28.0.2
@@ -844,7 +844,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 18.7.8
+      '@types/node': 18.7.14
       jest-mock: 28.1.3
 
   /@jest/expect-utils/28.1.3:
@@ -870,7 +870,7 @@ packages:
     dependencies:
       '@jest/types': 28.1.3
       '@sinonjs/fake-timers': 9.1.2
-      '@types/node': 18.7.8
+      '@types/node': 18.7.14
       jest-message-util: 28.1.3
       jest-mock: 28.1.3
       jest-util: 28.1.3
@@ -901,7 +901,7 @@ packages:
       '@jest/transform': 28.1.3
       '@jest/types': 28.1.3
       '@jridgewell/trace-mapping': 0.3.15
-      '@types/node': 18.7.8
+      '@types/node': 12.20.55
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
@@ -929,6 +929,13 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@sinclair/typebox': 0.24.28
+
+  /@jest/schemas/29.0.0:
+    resolution: {integrity: sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@sinclair/typebox': 0.24.28
+    dev: true
 
   /@jest/source-map/28.1.2:
     resolution: {integrity: sha512-cV8Lx3BeStJb8ipPHnqVw/IM2VCMWO3crWZzYodSIkxXnRcXJipCdx1JCK0K5MsJJouZQTH73mzf4vgxRaH9ww==}
@@ -989,9 +996,21 @@ packages:
       '@jest/schemas': 28.1.3
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 18.7.8
+      '@types/node': 18.7.14
       '@types/yargs': 17.0.11
       chalk: 4.1.2
+
+  /@jest/types/29.0.2:
+    resolution: {integrity: sha512-5WNMesBLmlkt1+fVkoCjHa0X3i3q8zc4QLTDkdHgCa2gyPZc7rdlZBWgVLqwS1860ZW5xJuCDwAzqbGaXIr/ew==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/schemas': 29.0.0
+      '@types/istanbul-lib-coverage': 2.0.4
+      '@types/istanbul-reports': 3.0.1
+      '@types/node': 12.20.55
+      '@types/yargs': 17.0.11
+      chalk: 4.1.2
+    dev: true
 
   /@jridgewell/gen-mapping/0.1.1:
     resolution: {integrity: sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==}
@@ -1076,7 +1095,7 @@ packages:
       unified: 10.1.2
       unist-util-position-from-estree: 1.1.1
       unist-util-stringify-position: 3.0.2
-      unist-util-visit: 4.1.0
+      unist-util-visit: 4.1.1
       vfile: 5.3.4
     transitivePeerDependencies:
       - supports-color
@@ -1088,7 +1107,7 @@ packages:
       react: '>=16'
     dependencies:
       '@types/mdx': 2.0.2
-      '@types/react': 18.0.17
+      '@types/react': 18.0.18
       react: 18.2.0
 
   /@napi-rs/simple-git-android-arm-eabi/0.1.8:
@@ -1514,7 +1533,7 @@ packages:
   /@types/graceful-fs/4.1.5:
     resolution: {integrity: sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==}
     dependencies:
-      '@types/node': 18.7.8
+      '@types/node': 12.20.55
     dev: true
 
   /@types/hast/2.3.4:
@@ -1552,7 +1571,7 @@ packages:
   /@types/keyv/3.1.4:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
-      '@types/node': 18.7.8
+      '@types/node': 12.20.55
     dev: true
 
   /@types/mdast/3.0.10:
@@ -1579,7 +1598,7 @@ packages:
   /@types/node-fetch/2.6.2:
     resolution: {integrity: sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==}
     dependencies:
-      '@types/node': 18.7.8
+      '@types/node': 18.7.14
       form-data: 3.0.1
     dev: true
 
@@ -1587,8 +1606,8 @@ packages:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
     dev: true
 
-  /@types/node/18.7.8:
-    resolution: {integrity: sha512-/YP55EMK2341JkODUb8DM9O0x1SIz2aBvyF33Uf1c76St3VpsMXEIW0nxuKkq/5cxnbz0RD9cfwNZHEAZQD3ag==}
+  /@types/node/18.7.14:
+    resolution: {integrity: sha512-6bbDaETVi8oyIARulOE9qF1/Qdi/23z6emrUh0fNJRUmjznqrixD4MpGDdgOFk5Xb0m2H6Xu42JGdvAxaJR/wA==}
 
   /@types/normalize-package-data/2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -1601,8 +1620,8 @@ packages:
   /@types/prop-types/15.7.5:
     resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
 
-  /@types/react/18.0.17:
-    resolution: {integrity: sha512-38ETy4tL+rn4uQQi7mB81G7V1g0u2ryquNmsVIOKUAEIDK+3CUjZ6rSRpdvS99dNBnkLFL83qfmtLacGOTIhwQ==}
+  /@types/react/18.0.18:
+    resolution: {integrity: sha512-6hI08umYs6NaiHFEEGioXnxJ+oEhY3eRz8VCUaudZmGdtvPviCJB8mgaMxaDWAdPSYd4eFavrPk2QIolwbLYrg==}
     dependencies:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.2
@@ -1611,7 +1630,7 @@ packages:
   /@types/responselike/1.0.0:
     resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
     dependencies:
-      '@types/node': 18.7.8
+      '@types/node': 12.20.55
     dev: true
 
   /@types/scheduler/0.16.2:
@@ -1880,7 +1899,7 @@ packages:
       postcss: ^8.1.0
     dependencies:
       browserslist: 4.21.3
-      caniuse-lite: 1.0.30001379
+      caniuse-lite: 1.0.30001385
       fraction.js: 4.2.0
       normalize-range: 0.1.2
       picocolors: 1.0.0
@@ -2143,6 +2162,10 @@ packages:
 
   /caniuse-lite/1.0.30001379:
     resolution: {integrity: sha512-zXf+qxuN8OJrK5Bl5HbJg8cc5/Zm01WNW4ooVWUh92YlKqQZW3fwN5lXLB+kI8wkP5vTWkIIN+rutZuJhf4ykw==}
+    dev: true
+
+  /caniuse-lite/1.0.30001385:
+    resolution: {integrity: sha512-MpiCqJGhBkHgpyimE9GWmZTnyHyEEM35u115bD3QBrXpjvL/JgcP8cUhKJshfmg4OtEHFenifcK5sZayEw5tvQ==}
 
   /cb2promise/1.1.1:
     resolution: {integrity: sha512-ShCxBARPFJlSO+Y4pxSpbXh6y+tW54Dmy4jKf0gB1C7qUslRqWqFi80+W9416zSoj6RsqMsnKUcpkt3bOrZmDg==}
@@ -3941,7 +3964,7 @@ packages:
       '@jest/expect': 28.1.3
       '@jest/test-result': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 18.7.8
+      '@types/node': 12.20.55
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -3986,46 +4009,6 @@ packages:
       - '@types/node'
       - supports-color
       - ts-node
-    dev: true
-
-  /jest-config/28.1.3_famynuxl7vhnyacjiboum65kqi:
-    resolution: {integrity: sha512-MG3INjByJ0J4AsNBm7T3hsuxKQqFIiRo/AUqb1q9LRKI5UU6Aar9JHbr9Ivn1TVwfUD9KirRoM/T6u8XlcQPHQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    peerDependencies:
-      '@types/node': '*'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      '@babel/core': 7.18.10
-      '@jest/test-sequencer': 28.1.3
-      '@jest/types': 28.1.3
-      '@types/node': 18.7.8
-      babel-jest: 28.1.3_@babel+core@7.18.10
-      chalk: 4.1.2
-      ci-info: 3.3.2
-      deepmerge: 4.2.2
-      glob: 7.2.3
-      graceful-fs: 4.2.10
-      jest-circus: 28.1.3
-      jest-environment-node: 28.1.3
-      jest-get-type: 28.0.2
-      jest-regex-util: 28.0.2
-      jest-resolve: 28.1.3
-      jest-runner: 28.1.3
-      jest-util: 28.1.3
-      jest-validate: 28.1.3
-      micromatch: 4.0.5
-      parse-json: 5.2.0
-      pretty-format: 28.1.3
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-      ts-node: 10.9.1_rf36vhyq5bw7w55ijgrvnfasgy
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /jest-config/28.1.3_ul4bw7p6zpcbqc5ta2hjpidvwy:
@@ -4103,7 +4086,7 @@ packages:
       '@jest/environment': 28.1.3
       '@jest/fake-timers': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 18.7.8
+      '@types/node': 12.20.55
       jest-mock: 28.1.3
       jest-util: 28.1.3
     dev: true
@@ -4119,7 +4102,7 @@ packages:
     dependencies:
       '@jest/types': 28.1.3
       '@types/graceful-fs': 4.1.5
-      '@types/node': 18.7.8
+      '@types/node': 12.20.55
       anymatch: 3.1.2
       fb-watchman: 2.0.1
       graceful-fs: 4.2.10
@@ -4169,7 +4152,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/types': 28.1.3
-      '@types/node': 18.7.8
+      '@types/node': 18.7.14
 
   /jest-pnp-resolver/1.2.2_jest-resolve@28.1.3:
     resolution: {integrity: sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==}
@@ -4222,7 +4205,7 @@ packages:
       '@jest/test-result': 28.1.3
       '@jest/transform': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 18.7.8
+      '@types/node': 12.20.55
       chalk: 4.1.2
       emittery: 0.10.2
       graceful-fs: 4.2.10
@@ -4308,7 +4291,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/types': 28.1.3
-      '@types/node': 18.7.8
+      '@types/node': 18.7.14
       chalk: 4.1.2
       ci-info: 3.3.2
       graceful-fs: 4.2.10
@@ -4348,7 +4331,7 @@ packages:
     dependencies:
       '@jest/test-result': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 18.7.8
+      '@types/node': 12.20.55
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.10.2
@@ -4360,7 +4343,7 @@ packages:
     resolution: {integrity: sha512-CqRA220YV/6jCo8VWvAt1KKx6eek1VIHMPeLEbpcfSfkEeWyBNppynM/o6q+Wmw+sOhos2ml34wZbSX3G13//g==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
-      '@types/node': 18.7.8
+      '@types/node': 12.20.55
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
@@ -4690,7 +4673,7 @@ packages:
     dependencies:
       '@types/mdast': 3.0.10
       '@types/unist': 2.0.6
-      unist-util-visit: 4.1.0
+      unist-util-visit: 4.1.1
     dev: false
 
   /mdast-util-find-and-replace/2.2.1:
@@ -4698,7 +4681,7 @@ packages:
     dependencies:
       escape-string-regexp: 5.0.0
       unist-util-is: 5.1.1
-      unist-util-visit-parents: 5.1.0
+      unist-util-visit-parents: 5.1.1
     dev: false
 
   /mdast-util-from-markdown/1.2.0:
@@ -4824,8 +4807,8 @@ packages:
       - supports-color
     dev: false
 
-  /mdast-util-to-hast/12.2.0:
-    resolution: {integrity: sha512-YDwT5KhGzLgPpSnQhAlK1+WpCW4gsPmNNAxUNMkMTDhxQyPp2eX86WOelnKnLKEvSpfxqJbPbInHFkefXZBhEA==}
+  /mdast-util-to-hast/12.2.1:
+    resolution: {integrity: sha512-dyindR2P7qOqXO1hQirZeGtVbiX7xlNQbw7gGaAwN4A1dh4+X8xU/JyYmRoyB8Fu1uPXzp7mlL5QwW7k+knvgA==}
     dependencies:
       '@types/hast': 2.3.4
       '@types/mdast': 3.0.10
@@ -4837,7 +4820,7 @@ packages:
       unist-builder: 3.0.0
       unist-util-generated: 2.0.0
       unist-util-position: 4.0.3
-      unist-util-visit: 4.1.0
+      unist-util-visit: 4.1.1
     dev: false
 
   /mdast-util-to-markdown/1.3.0:
@@ -4848,7 +4831,7 @@ packages:
       longest-streak: 3.0.1
       mdast-util-to-string: 3.1.0
       micromark-util-decode-string: 1.0.2
-      unist-util-visit: 4.1.0
+      unist-util-visit: 4.1.1
       zwitch: 2.0.2
     dev: false
 
@@ -5379,7 +5362,7 @@ packages:
     dependencies:
       '@next/env': 12.2.5
       '@swc/helpers': 0.4.3
-      caniuse-lite: 1.0.30001379
+      caniuse-lite: 1.0.30001385
       postcss: 8.4.14
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -6195,12 +6178,12 @@ packages:
     dependencies:
       '@types/hast': 2.3.4
       '@types/mdast': 3.0.10
-      mdast-util-to-hast: 12.2.0
+      mdast-util-to-hast: 12.2.1
       unified: 10.1.2
     dev: false
 
   /remove-accents/0.4.2:
-    resolution: {integrity: sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA==}
+    resolution: {integrity: sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U=}
     dev: false
 
   /repeating/2.0.1:
@@ -6821,7 +6804,7 @@ packages:
     dev: false
 
   /titleize/1.0.0:
-    resolution: {integrity: sha512-TARUb7z1pGvlLxgPk++7wJ6aycXF3GJ0sNSBTAsTuJrQG5QuZlkUQP+zl+nbjAh4gMX9yDw9ZYklMd7vAfJKEw==}
+    resolution: {integrity: sha1-fTUHIgYYMLpmF2MeDP0+oIOY2Vo=}
     engines: {node: '>=0.10.0'}
     dev: false
 
@@ -6896,7 +6879,7 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /ts-jest/28.0.8_lhw3xkmzugq5tscs3x2ndm4sby:
+  /ts-jest/28.0.8_csltoo4z63p2ffsse3qn3hzmuu:
     resolution: {integrity: sha512-5FaG0lXmRPzApix8oFG8RKjAz4ehtm8yMKOTy5HX3fY6W8kmvOrmcY0hKDElW52FJov+clhUbrKAqofnj4mXTg==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     hasBin: true
@@ -6917,7 +6900,7 @@ packages:
       esbuild:
         optional: true
     dependencies:
-      '@jest/types': 28.1.3
+      '@jest/types': 29.0.2
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       jest: 28.1.3_ul4bw7p6zpcbqc5ta2hjpidvwy
@@ -7273,7 +7256,7 @@ packages:
     resolution: {integrity: sha512-0yDkppiIhDlPrfHELgB+NLQD5mfjup3a8UYclHruTJWmY74je8g+CIFr79x5f6AkmzSwlvKLbs63hC0meOMowQ==}
     dependencies:
       '@types/unist': 2.0.6
-      unist-util-visit: 4.1.0
+      unist-util-visit: 4.1.1
     dev: false
 
   /unist-util-stringify-position/3.0.2:
@@ -7282,19 +7265,19 @@ packages:
       '@types/unist': 2.0.6
     dev: false
 
-  /unist-util-visit-parents/5.1.0:
-    resolution: {integrity: sha512-y+QVLcY5eR/YVpqDsLf/xh9R3Q2Y4HxkZTp7ViLDU6WtJCEcPmRzW1gpdWDCDIqIlhuPDXOgttqPlykrHYDekg==}
+  /unist-util-visit-parents/5.1.1:
+    resolution: {integrity: sha512-gks4baapT/kNRaWxuGkl5BIhoanZo7sC/cUT/JToSRNL1dYoXRFl75d++NkjYk4TAu2uv2Px+l8guMajogeuiw==}
     dependencies:
       '@types/unist': 2.0.6
       unist-util-is: 5.1.1
     dev: false
 
-  /unist-util-visit/4.1.0:
-    resolution: {integrity: sha512-n7lyhFKJfVZ9MnKtqbsqkQEk5P1KShj0+//V7mAcoI6bpbUjh3C/OG8HVD+pBihfh6Ovl01m8dkcv9HNqYajmQ==}
+  /unist-util-visit/4.1.1:
+    resolution: {integrity: sha512-n9KN3WV9k4h1DxYR1LoajgN93wpEi/7ZplVe02IoB4gH5ctI1AaF2670BLHQYbwj+pY83gFtyeySFiyMHJklrg==}
     dependencies:
       '@types/unist': 2.0.6
       unist-util-is: 5.1.1
-      unist-util-visit-parents: 5.1.0
+      unist-util-visit-parents: 5.1.1
     dev: false
 
   /universalify/0.1.2:


### PR DESCRIPTION
When @Zxilly is playing around with Next.js API Route with Experimental Edge Runtime, he tries to get a body from an empty response (where its statusCode could be 204, 205, or 304, etc.). He gets an empty TypeError with it.

When I am tracking down the issue through Next.js' source code, I notice that the only way Next.js could throw an empty TypeError is through the pre-compiled version of Edge Runtime. Further digging leads me to the `nodejs/undici`. Then I find out that `undici` has already fixed the issue (https://github.com/nodejs/undici/pull/1508). With that PR merged, `undici` now throws fetch spec compliant error instead of an empty TypeError.

This change is landed in `undici@5.6.0`, `edge-runtime` is still using `undici@5.5.0`, thus the empty TypeError is still occurring in Next.js Edge API Route.

The PR fixes the issue by bumping the version of `undici` to the latest version `5.9.1`.