### PR TITLE
fix(runtime): invalid typings

### DIFF
--- a/packages/primitives/type-definitions/abort-controller.d.ts
+++ b/packages/primitives/type-definitions/abort-controller.d.ts
@@ -1,18 +1,12 @@
-declare const AbortControllerConstructor: typeof AbortController
-declare const AbortSignalConstructor: typeof AbortSignal
-declare const DOMExceptionConstructor: typeof DOMException
+declare const AbortControllerConstructor: AbortController
 
-declare var WathwgAbortSignal: {
-  prototype: AbortSignalConstructor
-  new (): AbortSignalConstructor
+declare var AbortSignal: {
+  prototype: typeof AbortSignal
+  new (): typeof AbortSignal
   /** Returns an AbortSignal instance which will be aborted in milliseconds milliseconds. Its abort reason will be set to a "TimeoutError" DOMException. */
   timeout(milliseconds: number): AbortSignal
   /** Returns an AbortSignal instance whose abort reason is set to reason if not undefined; otherwise to an "AbortError" DOMException. */
   abort(reason?: string): AbortSignal
 }
 
-export {
-  AbortControllerConstructor as AbortController,
-  DOMExceptionConstructor as DOMException,
-  WathwgAbortSignal as AbortSignal,
-}
+export { AbortControllerConstructor as AbortController, AbortSignal }


### PR DESCRIPTION
### 📖 What's in there?

When @Kikobeats released 1.1.0-beta.29 and referenced it in Next.js (https://github.com/vercel/next.js/pull/39898), it [failed](https://github.com/vercel/next.js/runs/7992836032?check_suite_focus=true#step:11:190) because of the new `AbortSignal` types 

This PR fixes it

### 🧪 How to test it?

1. get your own copy of Next.js locally
2. in `edge-runtime` repository:
    ```bash
    pnpm i
    pnpm ln -g
    pnpm build
    ```
3. in `next.js` repository:
    ```bash
    cd packages/next
    pnpm ln -g edge-runtime @edge-runtime/primitives
    cd ../..
    pnpm --filter next ncc-compiled
    pnpm build
    ```

This should complete with no errors.