### PR TITLE
fix(vm): update `EdgeRuntime` definition from "edge-runtime" to "vercel"

### DIFF
--- a/packages/jest-environment/test/index.test.ts
+++ b/packages/jest-environment/test/index.test.ts
@@ -17,5 +17,5 @@ test('allows to run crypto', async () => {
 })
 
 test('has EdgeRuntime global', () => {
-  expect(EdgeRuntime).toEqual('edge-runtime')
+  expect(EdgeRuntime).toEqual('vercel')
 })

--- a/packages/runtime/tests/edge-runtime.test.ts
+++ b/packages/runtime/tests/edge-runtime.test.ts
@@ -190,15 +190,15 @@ test('gets a server error when responding with no response', async () => {
   expect(res.status).toEqual(500)
 })
 
-test('gets the runtime version in a hidden propety', async () => {
+test('gets the runtime version in a hidden property', async () => {
   const runtime = new EdgeRuntime()
   {
     const meta = runtime.evaluate(`(globalThis.EdgeRuntime)`)
-    expect(meta).toEqual('edge-runtime')
+    expect(meta).toEqual('vercel')
   }
   {
     const meta = runtime.evaluate(`(EdgeRuntime)`)
-    expect(meta).toEqual('edge-runtime')
+    expect(meta).toEqual('vercel')
   }
   const keys = runtime.evaluate<string[]>(`(Object.keys(globalThis))`)
   expect(keys).not.toHaveLength(0)

--- a/packages/vm/src/edge-vm.ts
+++ b/packages/vm/src/edge-vm.ts
@@ -90,7 +90,7 @@ function addPrimitives(context: VMContext) {
   defineProperty(context, 'clearTimeout', { value: clearTimeout })
   defineProperty(context, 'setInterval', { value: setInterval })
   defineProperty(context, 'setTimeout', { value: setTimeout })
-  defineProperty(context, 'EdgeRuntime', { value: 'edge-runtime' })
+  defineProperty(context, 'EdgeRuntime', { value: 'vercel' })
 
   // Console
   defineProperties(context, {


### PR DESCRIPTION
It looks like the value of `EdgeRuntime` changed from "edge-runtime" to "vercel". The docs don't mention a value, just to check that this is a string. The value in production is "vercel", though. So, I think this should match.

This is my first PR to this repo. If there's a convention I should follow, please let me know!