### PR TITLE
Add helper to validate body chunks

### DIFF
--- a/.changeset/eighty-badgers-beg.md
+++ b/.changeset/eighty-badgers-beg.md
@@ -1,0 +1,5 @@
+---
+'edge-runtime': patch
+---
+
+Add an util to validate chunks from `response.body`

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,2 +1,7 @@
-export { createHandler, runServer } from './server'
+export {
+  consumeUint8ArrayReadableStream,
+  createHandler,
+  runServer,
+} from './server'
+
 export { EdgeRuntime } from './edge-runtime'

--- a/packages/runtime/src/server/body-streams.ts
+++ b/packages/runtime/src/server/body-streams.ts
@@ -93,3 +93,26 @@ function replaceRequestBody<T extends IncomingMessage>(
 
   return base
 }
+
+/**
+ * Creates an async iterator from a ReadableStream that ensures that every
+ * emitted chunk is a `Uint8Array`. If there is some invalid chunk it will
+ * throw.
+ */
+export async function* consumeUint8ArrayReadableStream(body?: ReadableStream) {
+  const reader = body?.getReader()
+  if (reader) {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) {
+        return
+      }
+
+      if (value?.constructor?.name !== 'Uint8Array') {
+        throw new TypeError('This ReadableStream did not return bytes.')
+      }
+
+      yield value as Uint8Array
+    }
+  }
+}

--- a/packages/runtime/src/server/create-handler.ts
+++ b/packages/runtime/src/server/create-handler.ts
@@ -2,6 +2,7 @@ import type { EdgeRuntime } from '../edge-runtime'
 import type { IncomingMessage, ServerResponse } from 'http'
 import type { Logger, NodeHeaders } from '../types'
 import type { EdgeContext } from '@edge-runtime/vm'
+import { consumeUint8ArrayReadableStream } from './body-streams'
 import { getClonableBodyStream } from './body-streams'
 import prettyMs from 'pretty-ms'
 import status from 'http-status'
@@ -66,7 +67,9 @@ export function createHandler<T extends EdgeContext>(options: Options<T>) {
       }
 
       if (response.body) {
-        for await (const chunk of response.body as any) {
+        for await (const chunk of consumeUint8ArrayReadableStream(
+          response.body
+        )) {
           res.write(chunk)
         }
       }

--- a/packages/runtime/src/server/index.ts
+++ b/packages/runtime/src/server/index.ts
@@ -1,2 +1,3 @@
+export { consumeUint8ArrayReadableStream } from './body-streams'
 export { createHandler } from './create-handler'
 export { runServer } from './run-server'

--- a/packages/runtime/tests/server.test.ts
+++ b/packages/runtime/tests/server.test.ts
@@ -3,7 +3,28 @@ import { runServer } from '../src/server'
 import fetch from 'node-fetch'
 
 let server: Awaited<ReturnType<typeof runServer>>
-afterEach(() => server.close())
+
+const chunkErrorFn = jest.fn()
+jest.mock('../src/server/body-streams', () => {
+  const utils = jest.requireActual('../src/server/body-streams')
+  return {
+    ...utils,
+    consumeUint8ArrayReadableStream: async function* (body?: ReadableStream) {
+      try {
+        for await (const chunk of utils.consumeUint8ArrayReadableStream(body)) {
+          yield chunk
+        }
+      } catch (error) {
+        chunkErrorFn(error)
+      }
+    },
+  }
+})
+
+afterEach(() => {
+  server.close()
+  chunkErrorFn.mockReset()
+})
 
 test('starts an http server', async () => {
   const runtime = new EdgeRuntime()
@@ -131,4 +152,68 @@ test(`allows to wait for effects created with waitUntil`, async () => {
   expect(response).toBeTruthy()
   expect(response.status).toEqual(200)
   expect(resolved).toContain('done')
+})
+
+test(`do not fail writing to the response socket Uint8Array`, async () => {
+  const runtime = new EdgeRuntime()
+  runtime.evaluate(`
+    addEventListener('fetch', event => {
+      const stream = new ReadableStream({
+        start(controller) {
+          const encoder = new TextEncoder();
+          controller.enqueue(encoder.encode('hi there1\\n'));
+          controller.enqueue(encoder.encode('hi there2\\n'));
+          controller.enqueue(encoder.encode('hi there3\\n'));
+          controller.close();
+        }
+      });
+      return event.respondWith(
+        new Response(stream, {
+          status: 200,
+        })
+      )
+    })
+  `)
+  server = await runServer({ runtime })
+  const response = await fetch(server.url)
+  expect(response.status).toEqual(200)
+  const text = await response.text()
+  expect(text).toEqual('hi there1\nhi there2\nhi there3\n')
+  expect(chunkErrorFn).toHaveBeenCalledTimes(0)
+})
+
+test(`fails when writing to the response socket a wrong chunk`, async () => {
+  const chunks = [1, 'String', true, { b: 1 }, [1], Buffer.from('Buffer')]
+  const runtime = new EdgeRuntime()
+  runtime.evaluate(`
+      addEventListener('fetch', event => {
+        const url = new URL(event.request.url)
+        const chunk = url.searchParams.get('chunk')
+        const stream = new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('hi there'));
+            controller.enqueue(JSON.parse(chunk));
+            controller.close();
+          }
+        });
+        return event.respondWith(
+          new Response(stream, {
+            status: 200,
+          })
+        )
+      })
+    `)
+
+  server = await runServer({ runtime })
+  for (const chunk of chunks) {
+    const response = await fetch(`${server.url}?chunk=${JSON.stringify(chunk)}`)
+    expect(response.status).toEqual(200)
+    expect(await response.text()).toEqual('hi there')
+    expect(chunkErrorFn).toHaveBeenCalledTimes(1)
+    expect(chunkErrorFn.mock.calls[0][0]).toBeInstanceOf(TypeError)
+    expect(chunkErrorFn.mock.calls[0][0].message).toEqual(
+      'This ReadableStream did not return bytes.'
+    )
+    chunkErrorFn.mockReset()
+  }
 })


### PR DESCRIPTION
In Node.js `writable.write()` allows to pass not only `Uint8Array` but also `string`. Currently when a user creates a response with a stream that enqueues other types there is no validation when we read the chunks at put them in the Node.js server response which makes the write to fail and the server to hang.

With this PR we are adding a new helper that allows to create an async generator from the `response.body` `ReadableStream`. In this generator we will validate that the emitted chunk is a `Uint8Array` and if it is not we will throw an error. This will end up as an unhandled rejection failure since there is no way to handle the error as the response was already sent.

We also expose that util so that different server implementations can use it when piping the Edge Runtime response body into a Node.js Server.
