### PR TITLE
Fix `unhandledrejection` event shape

### DIFF
--- a/.changeset/serious-papayas-dance.md
+++ b/.changeset/serious-papayas-dance.md
@@ -1,0 +1,5 @@
+---
+'edge-runtime': patch
+---
+
+Fix `unhandledrejection` handler parameters

--- a/packages/runtime/src/edge-runtime.ts
+++ b/packages/runtime/src/edge-runtime.ts
@@ -68,7 +68,9 @@ export class EdgeRuntime<
 process.on(
   'unhandledRejection',
   function invokeRejectionHandlers(reason, promise) {
-    unhandledRejectionHandlers?.forEach((handler) => handler(reason, promise))
+    unhandledRejectionHandlers?.forEach((handler) =>
+      handler({ reason, promise })
+    )
   }
 )
 process.on('uncaughtException', function invokeErrorHandlers(error) {

--- a/packages/runtime/tests/edge-runtime.test.ts
+++ b/packages/runtime/tests/edge-runtime.test.ts
@@ -9,6 +9,7 @@ beforeAll(async () => {
     .spyOn(process, 'on')
     .mockImplementation((event: string, handler: Function) => {
       handlerByEvent.set(event, handler)
+      return process
     })
   ;({ EdgeRuntime } = await import('../src/edge-runtime'))
 })
@@ -60,13 +61,13 @@ test('invokes context rejection handler', async () => {
   const runtime = new EdgeRuntime()
 
   const handleRejection = jest.fn()
-  const error = new Error('Boom!!!')
+  const reason = new Error('Boom!!!')
   const promise = Promise.resolve()
   runtime.context.addEventListener('unhandledrejection', handleRejection)
 
   expect(handlerByEvent.get('unhandledRejection')).toBeDefined()
-  handlerByEvent.get('unhandledRejection')!(error, promise)
-  expect(handleRejection).toHaveBeenCalledWith(error, promise)
+  handlerByEvent.get('unhandledRejection')!(reason, promise)
+  expect(handleRejection).toHaveBeenCalledWith({ reason, promise })
   expect(handleRejection).toHaveBeenCalledTimes(1)
 })
 

--- a/packages/runtime/tests/unhandled-rejection.test.ts
+++ b/packages/runtime/tests/unhandled-rejection.test.ts
@@ -1,0 +1,14 @@
+import { exec } from 'child_process'
+import { promisify } from 'util'
+import { resolve } from 'path'
+
+jest.setTimeout(20000)
+
+it('handles correctly unhandled rejections', async () => {
+  const execAsync = promisify(exec)
+  const result = await execAsync(
+    `ts-node --transpile-only ${resolve(__dirname, 'unhandled-rejection.ts')}`,
+    { encoding: 'utf8' }
+  )
+  expect(result.stdout).toContain('TEST PASSED!')
+})

--- a/packages/runtime/tests/unhandled-rejection.ts
+++ b/packages/runtime/tests/unhandled-rejection.ts
@@ -1,0 +1,37 @@
+import { EdgeRuntime } from '../src'
+import assert from 'assert'
+
+async function main() {
+  const runtime = new EdgeRuntime()
+  const deferred = new Promise<PromiseRejectionEvent>((resolve) => {
+    runtime.context.handleRejection = (event: PromiseRejectionEvent) => {
+      resolve(event)
+    }
+  })
+
+  runtime.evaluate(`
+    addEventListener('fetch', (event) => {
+      new Promise((resolve, reject) => reject(new TypeError('This is not controlled')))
+      event.respondWith(new Response('hello'));
+    })
+
+    addEventListener('unhandledrejection', (event) => {
+      globalThis.handleRejection(event)
+    })
+  `)
+
+  const response = await runtime.dispatchFetch('https://example.com')
+  const event = await deferred
+
+  assert.strictEqual(response.status, 200)
+  assert.strictEqual(event.reason.message, 'This is not controlled')
+  return 'TEST PASSED!'
+}
+
+main()
+  .then(console.log)
+  .catch((error) => {
+    console.log('TEST FAILED!')
+    console.log(error)
+    process.exit(1)
+  })


### PR DESCRIPTION
Currently users can add an event listener using `addEventListener` for the `unhandledrejection` event. This handler is then invoked when an unhandled rejection occurs with an object that contains a `promise` and a `reason`. In Node.js the handler has a different signature and takes those two values into separated arguments. Currently we are invoking the handler using the Node.js signature while we should use `UnhandledPromiseRejection` instead. This PR fixes such issue and add some tests to ensure we are invoking the handler when there is an unhandled rejection.
