### PR TITLE
Update unhandled-rejection test to use a server

### DIFF
--- a/.changeset/nasty-poets-ring.md
+++ b/.changeset/nasty-poets-ring.md
@@ -1,0 +1,5 @@
+---
+'edge-runtime': patch
+---
+
+Fix: always finish the response when there is a bad chunk enqueued

--- a/packages/runtime/src/server/create-handler.ts
+++ b/packages/runtime/src/server/create-handler.ts
@@ -31,57 +31,63 @@ export function createHandler<T extends EdgeContext>(options: Options<T>) {
 
   return {
     handler: async (req: IncomingMessage, res: ServerResponse) => {
-      const start = timeSpan()
+      try {
+        const start = timeSpan()
 
-      const body =
-        req.method !== 'GET' && req.method !== 'HEAD'
-          ? getClonableBodyStream(
-              req,
-              options.runtime.evaluate('Uint8Array'),
-              options.runtime.context.TransformStream
-            )
-          : undefined
+        const body =
+          req.method !== 'GET' && req.method !== 'HEAD'
+            ? getClonableBodyStream(
+                req,
+                options.runtime.evaluate('Uint8Array'),
+                options.runtime.context.TransformStream
+              )
+            : undefined
 
-      const response = await options.runtime.dispatchFetch(
-        String(getURL(req)),
-        {
-          headers: toRequestInitHeaders(req),
-          method: req.method,
-          body: body?.cloneBodyStream(),
-        }
-      )
+        const response = await options.runtime.dispatchFetch(
+          String(getURL(req)),
+          {
+            headers: toRequestInitHeaders(req),
+            method: req.method,
+            body: body?.cloneBodyStream(),
+          }
+        )
 
-      const waitUntil = response.waitUntil()
-      awaiting.add(waitUntil)
-      waitUntil.finally(() => awaiting.delete(waitUntil))
+        const waitUntil = response.waitUntil()
+        awaiting.add(waitUntil)
+        waitUntil.finally(() => awaiting.delete(waitUntil))
 
-      res.statusCode = response.status
-      res.statusMessage = response.statusText
+        res.statusCode = response.status
+        res.statusMessage = response.statusText
 
-      for (const [key, value] of Object.entries(
-        toNodeHeaders(response.headers)
-      )) {
-        if (value !== undefined) {
-          res.setHeader(key, value)
-        }
-      }
-
-      if (response.body) {
-        for await (const chunk of consumeUint8ArrayReadableStream(
-          response.body
+        for (const [key, value] of Object.entries(
+          toNodeHeaders(response.headers)
         )) {
-          res.write(chunk)
+          if (value !== undefined) {
+            res.setHeader(key, value)
+          }
+        }
+
+        if (response.body) {
+          for await (const chunk of consumeUint8ArrayReadableStream(
+            response.body
+          )) {
+            res.write(chunk)
+          }
+        }
+
+        const subject = `${req.socket.remoteAddress} ${req.method} ${req.url}`
+        const time = `${prettyMs(start())
+          .match(/[a-zA-Z]+|[0-9]+/g)
+          ?.join(' ')}`
+
+        const code = `${res.statusCode} ${status[res.statusCode]}`
+        options.logger?.debug(`${subject} → ${code} in ${time}`)
+        res.end()
+      } finally {
+        if (!res.finished) {
+          res.end()
         }
       }
-
-      const subject = `${req.socket.remoteAddress} ${req.method} ${req.url}`
-      const time = `${prettyMs(start())
-        .match(/[a-zA-Z]+|[0-9]+/g)
-        ?.join(' ')}`
-
-      const code = `${res.statusCode} ${status[res.statusCode]}`
-      options.logger?.debug(`${subject} → ${code} in ${time}`)
-      res.end()
     },
 
     waitUntil: () => Promise.all(awaiting),


### PR DESCRIPTION
When we are streaming and equeue a bad chunk we are correctly emitting an unhandled rejection but aside from this we must finish the response to make sure the client doesn't hang waiting for more chunks. With this PR we tweak the test for unhandled rejection so that it uses the server and we can also assert that the response is correctly finished.