### PR TITLE
fix: don't delete headers in a redirect

### DIFF
--- a/.changeset/selfish-insects-suffer.md
+++ b/.changeset/selfish-insects-suffer.md
@@ -1,0 +1,5 @@
+---
+"edge-runtime": patch
+---
+
+fix: don't delete headers in a redirect

--- a/packages/runtime/src/edge-runtime.ts
+++ b/packages/runtime/src/edge-runtime.ts
@@ -152,9 +152,11 @@ function getDispatchFetchCode() {
 
       response.waitUntil = () => Promise.all(event.awaiting);
 
-      response.headers.delete('content-encoding');
-      response.headers.delete('transform-encoding');
-      response.headers.delete('content-length');
+      if (response.status < 300 || response.status >= 400 ) {
+        response.headers.delete('content-encoding');
+        response.headers.delete('transform-encoding');
+        response.headers.delete('content-length');
+      }
 
       return response;
     }


### PR DESCRIPTION
The Edge Runtime removes some unstable headers (see https://github.com/vercel/edge-runtime/pull/91) to be consistent to a regular fetch spec.

The thing is, under a redirect, headers can't be modified, so just I ward that lines to avoid users to threat with an unexpected error.

Plus, a redirect don't need to treat with headers since just 'location' is needed.

Closes #168