### PR TITLE
chore: bump pnpm@7.13.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
       "finepack"
     ]
   },
-  "packageManager": "pnpm@6.29.1",
+  "packageManager": "pnpm@7.13.5",
   "simple-git-hooks": {
     "pre-commit": "./node_modules/.bin/nano-staged"
   }


### PR DESCRIPTION
Looks like contributors to this project are already using pnpm 7 due to the lockfile so lets formalize it with [Corepack](https://nodejs.org/api/corepack.html).

Try it out with by running `corepack enable`.

More info: https://styfle.dev/blog/corepack