### PR TITLE
feat(cookies): make `RequestCookies` and `ResponseCookies` more spec compliant

### DIFF
--- a/.changeset/unlucky-icons-heal.md
+++ b/.changeset/unlucky-icons-heal.md
@@ -3,3 +3,8 @@
 ---
 
 Make `RequestCookies` and `ResponseCookies` more spec compliant by resembling the [Cookie Store API](https://wicg.github.io/cookie-store). The main difference is that the methods do not return `Promise`.
+
+Breaking changes:
+
+- `ResponseCookies#get` has been renamed to `ResponseCookies#getValue`
+- `ResponseCookies#getWithOptions` has been renamed to `ResponseCookies#get`

--- a/.changeset/unlucky-icons-heal.md
+++ b/.changeset/unlucky-icons-heal.md
@@ -1,0 +1,5 @@
+---
+'@edge-runtime/cookies': major
+---
+
+Make `RequestCookies` and `ResponseCookies` more spec compliant by resembling the [Cookie Store API](https://wicg.github.io/cookie-store). The main difference is that the methods do not return `Promise`.

--- a/packages/cookies/src/index.ts
+++ b/packages/cookies/src/index.ts
@@ -1,3 +1,3 @@
-export type { Options } from './serialize'
+export type { Cookie, CookieListItem } from './serialize'
 export { ResponseCookies } from './response-cookies'
 export { RequestCookies } from './request-cookies'

--- a/packages/cookies/src/request-cookies.ts
+++ b/packages/cookies/src/request-cookies.ts
@@ -1,80 +1,106 @@
-import { parseCookieString, serialize } from './serialize'
+import { type Cookie, parseCookieString, serialize } from './serialize'
 import { cached } from './cached'
 
 /**
  * A class for manipulating {@link Request} cookies.
  */
 export class RequestCookies {
-  private readonly headers: Headers
+  readonly #headers: Headers
 
   constructor(request: Request) {
-    this.headers = request.headers
+    this.#headers = request.headers
   }
 
-  /**
-   * Delete all the cookies in the cookies in the request
-   */
-  clear(): void {
-    this.delete([...this.parsed().keys()])
+  #cache = cached((header: string | null) => {
+    const parsed = header ? parseCookieString(header) : new Map()
+    return parsed
+  })
+
+  #parsed(): Map<string, string> {
+    const header = this.#headers.get('cookie')
+    return this.#cache(header)
   }
 
-  /**
-   * Format the cookies in the request as a string for logging
-   */
-  [Symbol.for('edge-runtime.inspect.custom')]() {
-    return `RequestCookies ${JSON.stringify(Object.fromEntries(this.parsed()))}`
+  [Symbol.iterator]() {
+    return this.#parsed()[Symbol.iterator]()
   }
 
   /**
    * The amount of cookies received from the client
    */
   get size(): number {
-    return this.parsed().size
+    return this.#parsed().size
   }
 
-  [Symbol.iterator]() {
-    return this.parsed()[Symbol.iterator]()
+  get(...args: [name: string] | [Cookie]) {
+    const name = typeof args[0] === 'string' ? args[0] : args[0].name
+    return this.#parsed().get(name)
   }
 
-  private cache = cached((header: string | null) => {
-    const parsed = header ? parseCookieString(header) : new Map()
-    return parsed
-  })
+  getAll(...args: [name: string] | [Cookie] | [undefined]) {
+    const all = Array.from(this.#parsed())
+    if (!args.length) {
+      return all
+    }
 
-  private parsed(): Map<string, string> {
-    const header = this.headers.get('cookie')
-    return this.cache(header)
-  }
-
-  get(name: string) {
-    return this.parsed().get(name)
+    const name = typeof args[0] === 'string' ? args[0] : args[0]?.name
+    return all.filter(([n]) => n === name)
   }
 
   has(name: string) {
-    return this.parsed().has(name)
+    return this.#parsed().has(name)
   }
 
-  set(name: string, value: string): this {
-    const map = this.parsed()
-    map.set(name, value)
-    this.headers.set(
+  set(...args: [key: string, value: string] | [options: Cookie]): this {
+    const [key, value] =
+      args.length === 1 ? [args[0].name, args[0].value, args[0]] : args
+
+    const map = this.#parsed()
+    map.set(key, value)
+
+    this.#headers.set(
       'cookie',
-      [...map].map(([key, value]) => serialize(key, value, {})).join('; ')
+      Array.from(map)
+        .map(([name, value]) => serialize({ name, value }))
+        .join('; ')
     )
     return this
   }
 
-  delete(names: string[]): boolean[]
-  delete(name: string): boolean
-  delete(names: string | string[]): boolean | boolean[] {
-    const map = this.parsed()
+  /**
+   * Delete the cookies matching the passed name or names in the request.
+   */
+  delete(
+    /** Name or names of the cookies to be deleted  */
+    names: string | string[]
+  ): boolean | boolean[] {
+    const map = this.#parsed()
     const result = !Array.isArray(names)
       ? map.delete(names)
       : names.map((name) => map.delete(name))
-    this.headers.set(
+    this.#headers.set(
       'cookie',
-      [...map].map(([key, value]) => serialize(key, value, {})).join('; ')
+      Array.from(map)
+        .map(([name, value]) => serialize({ name, value }))
+        .join('; ')
     )
     return result
+  }
+
+  /**
+   * Delete all the cookies in the cookies in the request.
+   */
+  clear(): this {
+    this.delete(Array.from(this.#parsed().keys()))
+    return this
+  }
+
+  /**
+   * Format the cookies in the request as a string for logging
+   */
+  [Symbol.for('edge-runtime.inspect.custom')]() {
+    return `RequestCookies ${JSON.stringify(
+      Object.fromEntries(this.#parsed())
+    )}`
   }
 }

--- a/packages/cookies/src/serialize.ts
+++ b/packages/cookies/src/serialize.ts
@@ -20,18 +20,20 @@ export interface CookieListItem
 export type Cookie = CookieListItem &
   Pick<CookieSerializeOptions, 'httpOnly' | 'maxAge' | 'priority'>
 
-export function serialize(c: Cookie): string {
+export function serialize(cookie: Cookie): string {
   const attrs = [
-    c.path ? `Path=${c.path}` : '',
-    c.expires ? `Expires=${c.expires.toUTCString()}` : '',
-    c.maxAge ? `Max-Age=${c.maxAge}` : '',
-    c.domain ? `Domain=${c.domain}` : '',
-    c.secure ? 'Secure' : '',
-    c.httpOnly ? 'HttpOnly' : '',
-    c.sameSite ? `SameSite=${c.sameSite}` : '',
+    cookie.path ? `Path=${cookie.path}` : '',
+    cookie.expires ? `Expires=${cookie.expires.toUTCString()}` : '',
+    cookie.maxAge ? `Max-Age=${cookie.maxAge}` : '',
+    cookie.domain ? `Domain=${cookie.domain}` : '',
+    cookie.secure ? 'Secure' : '',
+    cookie.httpOnly ? 'HttpOnly' : '',
+    cookie.sameSite ? `SameSite=${cookie.sameSite}` : '',
   ].filter(Boolean)
 
-  return `${c.name}=${encodeURIComponent(c.value ?? '')}; ${attrs.join('; ')}`
+  return `${cookie.name}=${encodeURIComponent(
+    cookie.value ?? ''
+  )}; ${attrs.join('; ')}`
 }
 
 /**

--- a/packages/cookies/test/response-cookies.test.ts
+++ b/packages/cookies/test/response-cookies.test.ts
@@ -5,36 +5,34 @@ it('reflect .set into `set-cookie`', async () => {
   const response = new Response()
   const cookies = new ResponseCookies(response)
 
-  expect(cookies.get('foo')).toBe(undefined)
-  expect(cookies.getWithOptions('foo')).toEqual({
-    value: undefined,
-    options: {},
-  })
+  expect(cookies.getValue('foo')).toBe(undefined)
+  expect(cookies.get('foo')).toEqual(undefined)
 
   cookies
     .set('foo', 'bar', { path: '/test' })
     .set('fooz', 'barz', { path: '/test2' })
     .set('fooHttpOnly', 'barHttpOnly', { httpOnly: true })
 
-  expect(cookies.get('foo')).toBe('bar')
-  expect(cookies.get('fooz')).toBe('barz')
-  expect(cookies.get('fooHttpOnly')).toBe('barHttpOnly')
+  expect(cookies.getValue('foo')).toBe('bar')
+  expect(cookies.getValue('fooz')).toBe('barz')
+  expect(cookies.getValue('fooHttpOnly')).toBe('barHttpOnly')
 
-  const opt1 = cookies.getWithOptions('foo')
+  const opt1 = cookies.get('foo')
   expect(opt1).toEqual<typeof opt1>({
+    name: 'foo',
     value: 'bar',
-    options: { path: '/test' },
+    path: '/test',
   })
-  expect(cookies.getWithOptions('fooz')).toEqual({
+  expect(cookies.get('fooz')).toEqual({
+    name: 'fooz',
     value: 'barz',
-    options: { path: '/test2' },
+    path: '/test2',
   })
-  expect(cookies.getWithOptions('fooHttpOnly')).toEqual({
+  expect(cookies.get('fooHttpOnly')).toEqual({
+    name: 'fooHttpOnly',
     value: 'barHttpOnly',
-    options: {
-      path: '/',
-      httpOnly: true,
-    },
+    path: '/',
+    httpOnly: true,
   })
 
   expect(Object.fromEntries(response.headers.entries())['set-cookie']).toBe(
@@ -51,10 +49,11 @@ it('reflect .delete into `set-cookie`', async () => {
     'foo=bar; Path=/'
   )
 
-  expect(cookies.get('foo')).toBe('bar')
-  expect(cookies.getWithOptions('foo')).toEqual({
+  expect(cookies.getValue('foo')).toBe('bar')
+  expect(cookies.get('foo')).toEqual({
+    name: 'foo',
     value: 'bar',
-    options: { path: '/' },
+    path: '/',
   })
 
   cookies.set('fooz', 'barz')
@@ -62,10 +61,11 @@ it('reflect .delete into `set-cookie`', async () => {
     'foo=bar; Path=/, fooz=barz; Path=/'
   )
 
-  expect(cookies.get('fooz')).toBe('barz')
-  expect(cookies.getWithOptions('fooz')).toEqual({
+  expect(cookies.getValue('fooz')).toBe('barz')
+  expect(cookies.get('fooz')).toEqual({
+    name: 'fooz',
     value: 'barz',
-    options: { path: '/' },
+    path: '/',
   })
 
   cookies.delete('foo')
@@ -73,10 +73,11 @@ it('reflect .delete into `set-cookie`', async () => {
     'foo=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT, fooz=barz; Path=/'
   )
 
-  expect(cookies.get('foo')).toBe('')
-  expect(cookies.getWithOptions('foo')).toEqual({
-    value: '',
-    options: { expires: new Date(0), path: '/' },
+  expect(cookies.getValue('foo')).toBe(undefined)
+  expect(cookies.get('foo')).toEqual({
+    name: 'foo',
+    path: '/',
+    expires: new Date(0),
   })
 
   cookies.delete('fooz')
@@ -85,10 +86,11 @@ it('reflect .delete into `set-cookie`', async () => {
     'foo=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT, fooz=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT'
   )
 
-  expect(cookies.get('fooz')).toBe('')
-  expect(cookies.getWithOptions('fooz')).toEqual({
-    value: '',
-    options: { expires: new Date(0), path: '/' },
+  expect(cookies.getValue('fooz')).toBe(undefined)
+  expect(cookies.get('fooz')).toEqual({
+    name: 'fooz',
+    expires: new Date(0),
+    path: '/',
   })
 })
 
@@ -111,6 +113,6 @@ test('formatting with @edge-runtime/format', () => {
   const format = createFormat()
   const result = format(cookies)
   expect(result).toMatchInlineSnapshot(
-    `"ResponseCookies {\\"a\\":{\\"value\\":\\"1\\",\\"options\\":{\\"httpOnly\\":true,\\"path\\":\\"/\\"}},\\"b\\":{\\"value\\":\\"2\\",\\"options\\":{\\"path\\":\\"/\\",\\"sameSite\\":\\"lax\\"}}}"`
+    `"ResponseCookies {\\"a\\":{\\"name\\":\\"a\\",\\"value\\":\\"1\\",\\"httpOnly\\":true,\\"path\\":\\"/\\"},\\"b\\":{\\"name\\":\\"b\\",\\"value\\":\\"2\\",\\"path\\":\\"/\\",\\"sameSite\\":\\"lax\\"}}"`
   )
 })

--- a/packages/cookies/test/response-cookies.test.ts
+++ b/packages/cookies/test/response-cookies.test.ts
@@ -14,7 +14,7 @@ it('reflect .set into `set-cookie`', async () => {
     .set('fooHttpOnly', 'barHttpOnly', { httpOnly: true })
 
   expect(cookies.getValue('foo')).toBe('bar')
-  expect(cookies.getValue('fooz')).toBe('barz')
+  expect(cookies.get('fooz')?.value).toBe('barz')
   expect(cookies.getValue('fooHttpOnly')).toBe('barHttpOnly')
 
   const opt1 = cookies.get('foo')


### PR DESCRIPTION
Changes based on the conversation in this [Slack thread](https://vercel.slack.com/archives/CGU8HUTUH/p1666109058231539).

Spec: https://wicg.github.io/cookie-store

Notable breaking changes:

- `ResponseCookies#get` has been renamed to `ResponseCookies#getValue` 
- `ResponseCookies#getWithOptions` has been renamed to `ResponseCookies#get` 