### PR TITLE
feat(cookies): extract `CookieStore` from `NextResponse`

### DIFF
--- a/.changeset/rotten-moose-carry.md
+++ b/.changeset/rotten-moose-carry.md
@@ -1,0 +1,5 @@
+---
+'@edge-runtime/cookies': major
+---
+
+Extract `CookieStore` to its own class

--- a/packages/cookies/src/cookie-store.ts
+++ b/packages/cookies/src/cookie-store.ts
@@ -1,0 +1,145 @@
+import type { CookieSerializeOptions } from 'cookie'
+import { cached } from './cached'
+import { parseSetCookieString, serialize } from './serialize'
+
+/**
+ * {@link https://wicg.github.io/cookie-store/#dictdef-cookielistitem CookieListItem} as specified by W3C.
+ */
+export interface CookieListItem
+  extends Pick<
+    CookieSerializeOptions,
+    'domain' | 'path' | 'expires' | 'secure' | 'sameSite'
+  > {
+  /** A string with the name of a cookie. */
+  name: string
+  /** A string containing the value of the cookie. */
+  value: string
+}
+
+/**
+ * Extends {@link CookieListItem} with the `httpOnly`, `maxAge` and `priority` properties.
+ */
+export type Cookie = CookieListItem &
+  Pick<CookieSerializeOptions, 'httpOnly' | 'maxAge' | 'priority'>
+
+export type CookieBag = Map<string, Cookie>
+
+export type CookieHeader = 'set-cookie' | 'cookie'
+
+/**
+ * Loose implementation of the experimental [Cookie Store API](https://wicg.github.io/cookie-store/#dictdef-cookie)
+ * The main difference is `CookieStore` methods do not return a Promise.
+ */
+export class CookieStore {
+  readonly #headers: Headers
+  readonly #cookieHeader: CookieHeader
+
+  constructor(
+    responseOrRequest: Response | Request,
+    cookieHeader: CookieHeader = 'set-cookie'
+  ) {
+    this.#headers = responseOrRequest.headers
+    this.#cookieHeader = cookieHeader
+  }
+
+  #cache = cached(() => {
+    // @ts-expect-error See https://github.com/whatwg/fetch/issues/973
+    const headers = this.#headers.getAll(this.#cookieHeader)
+    const map = new Map<string, Cookie>()
+
+    for (const header of headers) {
+      const parsed = parseSetCookieString(header)
+      if (parsed) {
+        map.set(parsed.name, parsed)
+      }
+    }
+
+    return map
+  })
+
+  #parsed() {
+    const allCookies = this.#headers.get(this.#cookieHeader)
+    return this.#cache(allCookies)
+  }
+
+  /**
+   * {@link https://wicg.github.io/cookie-store/#CookieStore-get CookieStore#get} without the Promise.
+   */
+  get(...args: [key: string] | [options: Cookie]): Cookie | undefined {
+    const key = typeof args[0] === 'string' ? args[0] : args[0].name
+    return this.#parsed().get(key)
+  }
+  /**
+   * {@link https://wicg.github.io/cookie-store/#CookieStore-getAll CookieStore#getAll} without the Promise.
+   */
+  getAll(...args: [key: string] | [options: Cookie] | [undefined]): Cookie[] {
+    const all = Array.from(this.#parsed().values())
+    if (!args.length) {
+      return all
+    }
+
+    const key = typeof args[0] === 'string' ? args[0] : args[0]?.name
+    return all.filter((c) => c.name === key)
+  }
+
+  /**
+   * {@link https://wicg.github.io/cookie-store/#CookieStore-set CookieStore#set} without the Promise.
+   */
+  set(
+    ...args:
+      | [key: string, value: string, cookie?: Partial<Cookie>]
+      | [options: Cookie]
+  ): this {
+    const [name, value, cookie] =
+      args.length === 1 ? [args[0].name, args[0].value, args[0]] : args
+    const map = this.#parsed()
+    map.set(name, normalizeCookie({ name, value, ...cookie }))
+    replace(map, this.#headers, this.#cookieHeader)
+
+    return this
+  }
+
+  /**
+   * {@link https://wicg.github.io/cookie-store/#CookieStore-delete CookieStore#delete} without the Promise.
+   */
+  delete(...args: [key: string] | [options: Cookie]): this {
+    const name = typeof args[0] === 'string' ? args[0] : args[0].name
+    return this.set({ name, value: '', expires: new Date(0) })
+  }
+
+  // Non-spec
+
+  /**
+   * Uses {@link CookieStore.delete} to invalidate all cookies matching the given name.
+   * If no name is provided, all cookies are invalidated.
+   */
+  clear(...args: [key: string] | [options: Cookie] | []): this {
+    const key = typeof args[0] === 'string' ? args[0] : args[0]?.name
+    this.getAll(key).forEach((c) => this.delete(c))
+    return this
+  }
+
+  [Symbol.for('edge-runtime.inspect.custom')]() {
+    return `CookieStore ${JSON.stringify(Object.fromEntries(this.#parsed()))}`
+  }
+}
+
+function replace(bag: CookieBag, headers: Headers, cookieHeader: CookieHeader) {
+  headers.delete(cookieHeader)
+  for (const [, value] of bag) {
+    const serialized = serialize(value)
+    headers.append(cookieHeader, serialized)
+  }
+}
+
+function normalizeCookie(cookie: Cookie = { name: '', value: '' }) {
+  if (cookie.maxAge) {
+    cookie.expires = new Date(Date.now() + cookie.maxAge * 1000)
+  }
+
+  if (cookie.path === null || cookie.path === undefined) {
+    cookie.path = '/'
+  }
+
+  return cookie
+}

--- a/packages/cookies/src/index.ts
+++ b/packages/cookies/src/index.ts
@@ -1,3 +1,3 @@
-export type { Cookie, CookieListItem } from './serialize'
+export * from './cookie-store'
 export { ResponseCookies } from './response-cookies'
 export { RequestCookies } from './request-cookies'

--- a/packages/cookies/src/request-cookies.ts
+++ b/packages/cookies/src/request-cookies.ts
@@ -1,4 +1,5 @@
-import { type Cookie, parseCookieString, serialize } from './serialize'
+import type { Cookie } from './cookie-store'
+import { parseCookieString, serialize } from './serialize'
 import { cached } from './cached'
 
 /**

--- a/packages/cookies/src/response-cookies.ts
+++ b/packages/cookies/src/response-cookies.ts
@@ -1,126 +1,35 @@
-import { cached } from './cached'
-import { type Cookie, parseSetCookieString, serialize } from './serialize'
+import { CookieStore } from './cookie-store'
 
-export type CookieBag = Map<string, Cookie>
-
-/**
- * Loose implementation of the experimental [Cookie Store API](https://wicg.github.io/cookie-store/#dictdef-cookie)
- * The main difference is `ResponseCookies` methods do not return a Promise.
- */
-export class ResponseCookies {
-  readonly #headers: Headers
-
+export class ResponseCookies extends CookieStore {
   constructor(response: Response) {
-    this.#headers = response.headers
-  }
-
-  #cache = cached(() => {
-    // @ts-expect-error See https://github.com/whatwg/fetch/issues/973
-    const headers = this.#headers.getAll('set-cookie')
-    const map = new Map<string, Cookie>()
-
-    for (const header of headers) {
-      const parsed = parseSetCookieString(header)
-      if (parsed) {
-        map.set(parsed.name, parsed)
-      }
-    }
-
-    return map
-  })
-
-  #parsed() {
-    const allCookies = this.#headers.get('set-cookie')
-    return this.#cache(allCookies)
+    super(response, 'set-cookie')
   }
 
   /**
    * {@link https://wicg.github.io/cookie-store/#CookieStore-get CookieStore#get} without the Promise.
    */
-  get(...args: [key: string] | [options: Cookie]): Cookie | undefined {
-    const key = typeof args[0] === 'string' ? args[0] : args[0].name
-    return this.#parsed().get(key)
-  }
+  get = super.get
+
   /**
    * {@link https://wicg.github.io/cookie-store/#CookieStore-getAll CookieStore#getAll} without the Promise.
    */
-  getAll(...args: [key: string] | [options: Cookie] | [undefined]): Cookie[] {
-    const all = Array.from(this.#parsed().values())
-    if (!args.length) {
-      return all
-    }
-
-    const key = typeof args[0] === 'string' ? args[0] : args[0]?.name
-    return all.filter((c) => c.name === key)
-  }
+  getAll = super.getAll
 
   /**
    * {@link https://wicg.github.io/cookie-store/#CookieStore-set CookieStore#set} without the Promise.
    */
-  set(
-    ...args:
-      | [key: string, value: string, cookie?: Partial<Cookie>]
-      | [options: Cookie]
-  ): this {
-    const [name, value, cookie] =
-      args.length === 1 ? [args[0].name, args[0].value, args[0]] : args
-    const map = this.#parsed()
-    map.set(name, normalizeCookie({ name, value, ...cookie }))
-    replace(map, this.#headers)
-
-    return this
-  }
+  set = super.set
 
   /**
    * {@link https://wicg.github.io/cookie-store/#CookieStore-delete CookieStore#delete} without the Promise.
    */
-  delete(...args: [key: string] | [options: Cookie]): this {
-    const name = typeof args[0] === 'string' ? args[0] : args[0].name
-    return this.set({ name, value: '', expires: new Date(0) })
-  }
+  delete = super.delete
 
   // Non-spec
 
   /**
-   * Uses {@link ResponseCookies.get} to return only the cookie value.
-   */
-  getValue(...args: [key: string] | [options: Cookie]): string | undefined {
-    return this.get(...args)?.value
-  }
-
-  /**
-   * Uses {@link ResponseCookies.delete} to invalidate all cookies matching the given name.
+   * Uses {@link CookieStore.delete} to invalidate all cookies matching the given name.
    * If no name is provided, all cookies are invalidated.
    */
-  clear(...args: [key: string] | [options: Cookie] | [undefined]): this {
-    const key = typeof args[0] === 'string' ? args[0] : args[0]?.name
-    this.getAll(key).forEach((c) => this.delete(c))
-    return this
-  }
-
-  [Symbol.for('edge-runtime.inspect.custom')]() {
-    return `ResponseCookies ${JSON.stringify(
-      Object.fromEntries(this.#parsed())
-    )}`
-  }
-}
-
-function replace(bag: CookieBag, headers: Headers) {
-  headers.delete('set-cookie')
-  for (const [, value] of bag) {
-    const serialized = serialize(value)
-    headers.append('set-cookie', serialized)
-  }
-}
-
-function normalizeCookie(cookie: Cookie = { name: '', value: '' }) {
-  if (cookie.maxAge) {
-    cookie.expires = new Date(Date.now() + cookie.maxAge * 1000)
-  }
-
-  if (cookie.path === null || cookie.path === undefined) {
-    cookie.path = '/'
-  }
-
-  return cookie
+  clear = super.clear
 }

--- a/packages/cookies/src/serialize.ts
+++ b/packages/cookies/src/serialize.ts
@@ -1,24 +1,4 @@
-import type { CookieSerializeOptions } from 'cookie'
-
-/**
- * {@link https://wicg.github.io/cookie-store/#dictdef-cookielistitem CookieListItem} as specified by W3C.
- */
-export interface CookieListItem
-  extends Pick<
-    CookieSerializeOptions,
-    'domain' | 'path' | 'expires' | 'secure' | 'sameSite'
-  > {
-  /** A string with the name of a cookie. */
-  name: string
-  /** A string containing the value of the cookie. */
-  value: string
-}
-
-/**
- * Extends {@link CookieListItem} with the `httpOnly`, `maxAge` and `priority` properties.
- */
-export type Cookie = CookieListItem &
-  Pick<CookieSerializeOptions, 'httpOnly' | 'maxAge' | 'priority'>
+import type { Cookie } from './cookie-store'
 
 export function serialize(cookie: Cookie): string {
   const attrs = [

--- a/packages/cookies/test/response-cookies.test.ts
+++ b/packages/cookies/test/response-cookies.test.ts
@@ -5,7 +5,7 @@ it('reflect .set into `set-cookie`', async () => {
   const response = new Response()
   const cookies = new ResponseCookies(response)
 
-  expect(cookies.getValue('foo')).toBe(undefined)
+  expect(cookies.get('foo')?.value).toBe(undefined)
   expect(cookies.get('foo')).toEqual(undefined)
 
   cookies
@@ -13,9 +13,9 @@ it('reflect .set into `set-cookie`', async () => {
     .set('fooz', 'barz', { path: '/test2' })
     .set('fooHttpOnly', 'barHttpOnly', { httpOnly: true })
 
-  expect(cookies.getValue('foo')).toBe('bar')
+  expect(cookies.get('foo')?.value).toBe('bar')
   expect(cookies.get('fooz')?.value).toBe('barz')
-  expect(cookies.getValue('fooHttpOnly')).toBe('barHttpOnly')
+  expect(cookies.get('fooHttpOnly')?.value).toBe('barHttpOnly')
 
   const opt1 = cookies.get('foo')
   expect(opt1).toEqual<typeof opt1>({
@@ -49,7 +49,7 @@ it('reflect .delete into `set-cookie`', async () => {
     'foo=bar; Path=/'
   )
 
-  expect(cookies.getValue('foo')).toBe('bar')
+  expect(cookies.get('foo')?.value).toBe('bar')
   expect(cookies.get('foo')).toEqual({
     name: 'foo',
     value: 'bar',
@@ -61,7 +61,7 @@ it('reflect .delete into `set-cookie`', async () => {
     'foo=bar; Path=/, fooz=barz; Path=/'
   )
 
-  expect(cookies.getValue('fooz')).toBe('barz')
+  expect(cookies.get('fooz')?.value).toBe('barz')
   expect(cookies.get('fooz')).toEqual({
     name: 'fooz',
     value: 'barz',
@@ -73,7 +73,7 @@ it('reflect .delete into `set-cookie`', async () => {
     'foo=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT, fooz=barz; Path=/'
   )
 
-  expect(cookies.getValue('foo')).toBe(undefined)
+  expect(cookies.get('foo')?.value).toBe(undefined)
   expect(cookies.get('foo')).toEqual({
     name: 'foo',
     path: '/',
@@ -86,7 +86,7 @@ it('reflect .delete into `set-cookie`', async () => {
     'foo=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT, fooz=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT'
   )
 
-  expect(cookies.getValue('fooz')).toBe(undefined)
+  expect(cookies.get('fooz')?.value).toBe(undefined)
   expect(cookies.get('fooz')).toEqual({
     name: 'fooz',
     expires: new Date(0),
@@ -113,6 +113,6 @@ test('formatting with @edge-runtime/format', () => {
   const format = createFormat()
   const result = format(cookies)
   expect(result).toMatchInlineSnapshot(
-    `"ResponseCookies {\\"a\\":{\\"name\\":\\"a\\",\\"value\\":\\"1\\",\\"httpOnly\\":true,\\"path\\":\\"/\\"},\\"b\\":{\\"name\\":\\"b\\",\\"value\\":\\"2\\",\\"path\\":\\"/\\",\\"sameSite\\":\\"lax\\"}}"`
+    `"CookieStore {\\"a\\":{\\"name\\":\\"a\\",\\"value\\":\\"1\\",\\"httpOnly\\":true,\\"path\\":\\"/\\"},\\"b\\":{\\"name\\":\\"b\\",\\"value\\":\\"2\\",\\"path\\":\\"/\\",\\"sameSite\\":\\"lax\\"}}"`
   )
 })


### PR DESCRIPTION
Also removes the non-spec `getValue()` in favor of `get()?.value`. This is needed to land: https://github.com/vercel/next.js/pull/41526