### PR TITLE
fix: fall back to `headers#get` when `headers#getAll` unavailable

### DIFF
--- a/.changeset/tricky-carrots-smash.md
+++ b/.changeset/tricky-carrots-smash.md
@@ -3,4 +3,4 @@
 'edge-runtime': patch
 ---
 
-fall back to `headers#get` when `headers#getAll` unavailebl for `set-cookie` header
+fall back to `headers#get` when `headers#getAll` unavailable for `set-cookie` header

--- a/.changeset/tricky-carrots-smash.md
+++ b/.changeset/tricky-carrots-smash.md
@@ -1,0 +1,6 @@
+---
+'@edge-runtime/cookies': patch
+'edge-runtime': patch
+---
+
+fall back to `headers#get` when `headers#getAll` unavailebl for `set-cookie` header

--- a/packages/cookies/src/response-cookies.ts
+++ b/packages/cookies/src/response-cookies.ts
@@ -14,8 +14,11 @@ export class ResponseCookies {
 
   constructor(responseHeaders: Headers) {
     this._headers = responseHeaders
-    // @ts-expect-error See https://github.com/whatwg/fetch/issues/973
-    const headers = this._headers.getAll('set-cookie')
+    const headers =
+      // @ts-expect-error See https://github.com/whatwg/fetch/issues/973
+      this._headers.getAll?.('set-cookie') ??
+      this._headers.get('set-cookie')?.split(', ') ??
+      []
 
     for (const header of headers) {
       const parsed = parseSetCookieString(header)

--- a/packages/cookies/test/response-cookies.test.ts
+++ b/packages/cookies/test/response-cookies.test.ts
@@ -113,6 +113,22 @@ test('cookies.toString()', () => {
   expect(cookies.toString()).toMatch('foo=bar; Path=/test; fooz=barz; Path=/')
 })
 
+test('use headers.get when .getAll is unavailable', () => {
+  // @ts-expect-error
+  const orgGetAll = Headers.prototype.getAll
+  // @ts-expect-error
+  delete Headers.prototype.getAll
+  const headers = new Headers()
+  headers.append('set-cookie', 'foo=bar; Path=/')
+  headers.append('set-cookie', 'fooz=barz; Path=/')
+  const cookies = new ResponseCookies(headers)
+
+  expect(cookies.toString()).toBe('foo=bar; Path=/; fooz=barz; Path=/')
+
+  // @ts-expect-error
+  Headers.prototype.getAll = orgGetAll
+})
+
 test('formatting with @edge-runtime/format', () => {
   const headers = new Headers()
   const cookies = new ResponseCookies(headers)

--- a/packages/cookies/test/response-cookies.test.ts
+++ b/packages/cookies/test/response-cookies.test.ts
@@ -119,6 +119,10 @@ test('use headers.get when .getAll is unavailable', () => {
   // @ts-expect-error
   delete Headers.prototype.getAll
   const headers = new Headers()
+
+  // @ts-expect-error
+  expect(headers.getAll).toBe(undefined)
+
   headers.append('set-cookie', 'foo=bar; Path=/')
   headers.append('set-cookie', 'fooz=barz; Path=/')
   const cookies = new ResponseCookies(headers)
@@ -127,6 +131,8 @@ test('use headers.get when .getAll is unavailable', () => {
 
   // @ts-expect-error
   Headers.prototype.getAll = orgGetAll
+  // @ts-expect-error
+  expect(typeof new Headers().getAll).toBe('function')
 })
 
 test('formatting with @edge-runtime/format', () => {

--- a/packages/runtime/src/server/create-handler.ts
+++ b/packages/runtime/src/server/create-handler.ts
@@ -127,8 +127,10 @@ function toNodeHeaders(headers?: Headers): NodeHeaders {
     for (const [key, value] of headers.entries()) {
       result[key] =
         key.toLowerCase() === 'set-cookie'
-          ? // @ts-ignore getAll is hidden in Headers but exists.
-            headers.getAll('set-cookie')
+          ? // @ts-expect-error getAll is hidden in Headers but exists.
+            headers.getAll?.('set-cookie') ??
+            headers.get('set-cookie')?.split(', ') ??
+            []
           : value
     }
   }


### PR DESCRIPTION
Related: https://github.com/vercel/next.js/issues/42374 when released, this should be included in https://github.com/vercel/next.js/pull/42736 also