### PR TITLE
fix: ignore missing type for alias

### DIFF
--- a/packages/primitives/scripts/build.ts
+++ b/packages/primitives/scripts/build.ts
@@ -50,6 +50,7 @@ async function bundlePackage() {
       process: JSON.stringify({ env: {}, versions: { node: '16.6.0' } }),
     },
     esbuildPlugins: [
+      // @ts-ignore
       alias({
         'util/types': resolve('src/patches/util-types.js'),
       }),


### PR DESCRIPTION
Hello,

TS is crying because the right types for https://github.com/igoradamenko/esbuild-plugin-alias in our current esbuild version is missing:

<img width="1064" alt="CleanShot 2023-01-19 at 18 42 16@2x" src="https://user-images.githubusercontent.com/2096101/213520045-3c88c9b3-f94c-4ec7-9823-f5788b0f2169.png">

However, the library can still be used as usual. I verified that checking `dist/fetch` is using our `util/types` patch for node12:

<img width="950" alt="CleanShot 2023-01-19 at 18 43 29@2x" src="https://user-images.githubusercontent.com/2096101/213520296-8c45068a-02c4-4741-9387-d4f224e26489.png">

