### PR TITLE
Update package.json - missing `dist` folder

### DIFF
--- a/.changeset/happy-coins-grow.md
+++ b/.changeset/happy-coins-grow.md
@@ -1,0 +1,5 @@
+---
+'@edge-runtime/ponyfill': patch
+---
+
+Added dist folder to files key in package.json

--- a/package.json
+++ b/package.json
@@ -82,6 +82,10 @@
     {
       "name": "Steren",
       "email": "steren.giannini@gmail.com"
+    },
+    {
+      "name": "Scott Vanderbeek",
+      "email": "scott@theawesomescott.com"
     }
   ],
   "repository": {

--- a/packages/ponyfill/package.json
+++ b/packages/ponyfill/package.json
@@ -2,7 +2,7 @@
   "name": "@edge-runtime/ponyfill",
   "description": "A ponyfill (doesn't overwrite the native methods) to use Edge Runtime APIs in any environment.",
   "homepage": "https://edge-runtime.vercel.app/packages/ponyfill",
-  "version": "2.0.1",
+  "version": "2.0.0",
   "main": "src/index.js",
   "module": "dist/index.mjs",
   "repository": {

--- a/packages/ponyfill/package.json
+++ b/packages/ponyfill/package.json
@@ -2,7 +2,7 @@
   "name": "@edge-runtime/ponyfill",
   "description": "A ponyfill (doesn't overwrite the native methods) to use Edge Runtime APIs in any environment.",
   "homepage": "https://edge-runtime.vercel.app/packages/ponyfill",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "src/index.js",
   "module": "dist/index.mjs",
   "repository": {
@@ -38,6 +38,7 @@
     "node": ">=14"
   },
   "files": [
+    "dist",
     "src"
   ],
   "scripts": {


### PR DESCRIPTION
This PR adds the missing `dist` folder to `files` in the `package.json` for `@edge-runtime/ponyfill` so the `module` entry can be resolved.