### PR TITLE
feat(node-utils): uses host header and mocks waitUntil()

### DIFF
--- a/.changeset/curvy-bikes-greet.md
+++ b/.changeset/curvy-bikes-greet.md
@@ -1,0 +1,5 @@
+---
+'@edge-runtime/node-utils': major
+---
+
+Provides mocked fetch event which throws when using `waitUntil`. `buildToNodeHandler()`'s dependencies now requires `FetchEvent` constructor.

--- a/.changeset/dry-cheetahs-fail.md
+++ b/.changeset/dry-cheetahs-fail.md
@@ -1,5 +1,5 @@
 ---
-'@edge-runtime/node-utils': minor
+'@edge-runtime/node-utils': major
 ---
 
-Uses host header as request origin when available
+Uses host header as request origin when available. `buildToNodeHandler()`'s `origin` option has been renamed into `defaultOrigin`.

--- a/.changeset/dry-cheetahs-fail.md
+++ b/.changeset/dry-cheetahs-fail.md
@@ -1,0 +1,5 @@
+---
+'@edge-runtime/node-utils': minor
+---
+
+Uses host header as request origin when available

--- a/docs/pages/packages/node-utils.mdx
+++ b/docs/pages/packages/node-utils.mdx
@@ -68,6 +68,7 @@ List of Web globals used by the transformer function:
 - [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers)
 - [ReadableStream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream)
 - [Uint8Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array)
+- [FetchEvent](https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent)
 
 When running in Node.js 18+ (or Node.js 16 with [--experimental-fetch](https://nodejs.org/docs/latest-v16.x/api/cli.html#node_optionsoptions)), you may pass the ones from `global` scope.
 
@@ -103,6 +104,13 @@ In case no host is provided, this default origin will be used instead.
 
 Builds a transformer function to turn a Node.js [IncomingMessage](https://nodejs.org/api/http.html#class-httpincomingmessage) into a Web [Request].
 It needs globals Web contstructor a [dependencies](#dependencies-object), as well as [options](#options-object) to handle incoming url.
+
+### buildToFetchEvent(dependencies): toFetchEvent(request: Request): FetchEvent
+
+Builds a transformer function to build a fetch event from a web [Request].
+The returned event is linked to provided request, and has a mocked [waitUntil()](https://developer.mozilla.org/en-US/docs/Web/API/ExtendableEvent/waitUntil) method, which throws on access.
+
+It needs globals Web contstructor a [dependencies](#dependencies-object).
 
 ### toOutgoingHeaders(headers: Headers): OutgoingHttpHeaders
 

--- a/docs/pages/packages/node-utils.mdx
+++ b/docs/pages/packages/node-utils.mdx
@@ -11,22 +11,10 @@ The **@edge-runtime/node-utils** package contains utilities to run web compliant
 
 ## Installation
 
-<Tabs items={['npm', 'yarn', 'pnpm']} storageKey="selected-pkg-manager">
-  <Tab>
-    ```sh
-    npm install @edge-runtime/node-utils --save
-    ```
-  </Tab>
-  <Tab>
-    ```sh
-    yarn add @edge-runtime/node-utils
-    ```
-  </Tab>
-  <Tab>
-    ```sh
-    pnpm install @edge-runtime/node-utils --save
-    ```
-  </Tab>
+<Tabs items={['npm', 'yarn', 'pnpm']} storageKey='selected-pkg-manager'>
+  <Tab>```sh npm install @edge-runtime/node-utils --save ```</Tab>
+  <Tab>```sh yarn add @edge-runtime/node-utils ```</Tab>
+  <Tab>```sh pnpm install @edge-runtime/node-utils --save ```</Tab>
 </Tabs>
 
 This package includes built-in TypeScript support.
@@ -40,7 +28,7 @@ import { buildToNodeHandler } from '@edge-runtime/node-utils'
 
 // 1. builds a transformer, using Node.js@18 globals, and a base url for URL constructor.
 const transformToNode = buildToNodeHandler(global, {
-  origin: 'http://example.com',
+  defaultOrigin: 'http://example.com',
 })
 
 const server = await createServer(
@@ -106,9 +94,10 @@ buildToNodeHandler(primitives, {
 
 Options used to build the transformer function, including:
 
-##### origin: string
+##### defaultOrigin: string
 
-Origin used to turn the incoming request relative url into a full [Request.url](https://developer.mozilla.org/en-US/docs/Web/API/Request/url) string.
+The incoming [`host` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/host) is used when turning the incoming request relative url into a full [Request.url](https://developer.mozilla.org/en-US/docs/Web/API/Request/url) string.
+In case no host is provided, this default origin will be used instead.
 
 ### buildToRequest(dependencies, options): toRequest(request: IncomingMessage, options: object): Request
 

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "esbuild": "0.17.4",
     "finepack": "latest",
     "git-authors-cli": "latest",
-    "jest": "29.4.0",
+    "jest": "29.3.1",
     "jest-watch-typeahead": "2.2.1",
     "nano-staged": "latest",
     "prettier": "latest",

--- a/packages/node-utils/src/node-to-edge/fetch-event.ts
+++ b/packages/node-utils/src/node-to-edge/fetch-event.ts
@@ -1,0 +1,16 @@
+import type { Request } from '@edge-runtime/primitives'
+import { BuildDependencies } from '../types'
+
+export function buildToFetchEvent(dependencies: BuildDependencies) {
+  return function toFetchEvent(request: Request) {
+    const event = new dependencies.FetchEvent(request)
+    Object.defineProperty(event, 'waitUntil', {
+      configurable: false,
+      enumerable: true,
+      get: () => {
+        throw new Error('waitUntil is not supported yet.')
+      },
+    })
+    return event
+  }
+}

--- a/packages/node-utils/src/node-to-edge/index.ts
+++ b/packages/node-utils/src/node-to-edge/index.ts
@@ -1,3 +1,4 @@
+export * from './fetch-event'
 export * from './headers'
 export * from './request'
 export * from './stream'

--- a/packages/node-utils/src/node-to-edge/request.ts
+++ b/packages/node-utils/src/node-to-edge/request.ts
@@ -12,12 +12,29 @@ export function buildToRequest(dependencies: BuildDependencies) {
     request: IncomingMessage,
     options: RequestOptions
   ): Request {
-    return new Request(String(new URL(request.url || '/', options.origin)), {
-      method: request.method,
-      headers: toHeaders(request.headers),
-      body: !['HEAD', 'GET'].includes(request.method ?? '')
-        ? toReadableStream(request)
-        : null,
-    })
+    return new Request(
+      String(
+        new URL(
+          request.url || '/',
+          computeOrigin(request, options.defaultOrigin)
+        )
+      ),
+      {
+        method: request.method,
+        headers: toHeaders(request.headers),
+        body: !['HEAD', 'GET'].includes(request.method ?? '')
+          ? toReadableStream(request)
+          : null,
+      }
+    )
   }
+}
+
+function computeOrigin({ headers }: IncomingMessage, defaultOrigin: string) {
+  const authority = headers.host
+  if (!authority) {
+    return defaultOrigin
+  }
+  const [, port] = authority.split(':')
+  return `${port === '443' ? 'https' : 'http'}://${authority}`
 }

--- a/packages/node-utils/src/types.ts
+++ b/packages/node-utils/src/types.ts
@@ -13,7 +13,7 @@ export interface BuildDependencies {
 }
 
 export interface RequestOptions {
-  origin: string
+  defaultOrigin: string
 }
 
 export type NodeHandler = (

--- a/packages/node-utils/src/types.ts
+++ b/packages/node-utils/src/types.ts
@@ -4,12 +4,14 @@ import type {
   Response,
   Headers,
   ReadableStream,
+  FetchEvent,
 } from '@edge-runtime/primitives'
 export interface BuildDependencies {
   Headers: typeof Headers
   ReadableStream: typeof ReadableStream
   Request: typeof Request
   Uint8Array: typeof Uint8Array
+  FetchEvent: typeof FetchEvent
 }
 
 export interface RequestOptions {
@@ -22,5 +24,6 @@ export type NodeHandler = (
 ) => Promise<void> | void
 
 export type WebHandler = (
-  req: Request
+  req: Request,
+  event: FetchEvent
 ) => Promise<Response> | Response | null | undefined

--- a/packages/node-utils/test/edge-to-node/handler.test.ts
+++ b/packages/node-utils/test/edge-to-node/handler.test.ts
@@ -11,7 +11,7 @@ const transformToNode = buildToNodeHandler(
     Request: Edge.Request,
     Uint8Array: Uint8Array,
   },
-  { origin: 'http://example.com' }
+  { defaultOrigin: 'http://example.com' }
 )
 
 let server: TestServer

--- a/packages/node-utils/test/edge-to-node/handler.test.ts
+++ b/packages/node-utils/test/edge-to-node/handler.test.ts
@@ -10,6 +10,7 @@ const transformToNode = buildToNodeHandler(
     ReadableStream: Edge.ReadableStream,
     Request: Edge.Request,
     Uint8Array: Uint8Array,
+    FetchEvent: Edge.FetchEvent,
   },
   { defaultOrigin: 'http://example.com' }
 )
@@ -227,5 +228,21 @@ it('consumes incoming headers', async () => {
     status: 200,
     statusText: 'OK',
     headers,
+  })
+})
+
+it('fails when using waitUntil()', async () => {
+  server = await runTestServer({
+    handler: transformToNode((req, evt) => {
+      evt.waitUntil(Promise.resolve())
+      return new Edge.Response('ok')
+    }),
+  })
+
+  const response = await server.fetch('/')
+  expect(await serializeResponse(response)).toMatchObject({
+    status: 500,
+    statusText: 'Internal Server Error',
+    text: 'Error: waitUntil is not supported yet.',
   })
 })

--- a/packages/node-utils/test/node-to-edge/fetch-event.test.ts
+++ b/packages/node-utils/test/node-to-edge/fetch-event.test.ts
@@ -1,0 +1,25 @@
+import * as EdgeRuntime from '@edge-runtime/primitives'
+import { buildToFetchEvent } from '../../src'
+
+const toFetchEvent = buildToFetchEvent({
+  Headers: EdgeRuntime.Headers,
+  ReadableStream: EdgeRuntime.ReadableStream,
+  Request: EdgeRuntime.Request,
+  Uint8Array: Uint8Array,
+  FetchEvent: EdgeRuntime.FetchEvent,
+})
+
+it('returns a fetch event with a request', () => {
+  const request = new EdgeRuntime.Request('https://vercel.com')
+  const event = toFetchEvent(request)
+  expect(event).toBeInstanceOf(EdgeRuntime.FetchEvent)
+  expect(event.request).toBe(request)
+})
+
+it('throws when accessing waitUntil', () => {
+  const request = new EdgeRuntime.Request('https://vercel.com')
+  const event = toFetchEvent(request)
+  expect(() => event.waitUntil(Promise.resolve())).toThrow(
+    'waitUntil is not supported yet.'
+  )
+})

--- a/packages/node-utils/test/node-to-edge/request.test.ts
+++ b/packages/node-utils/test/node-to-edge/request.test.ts
@@ -10,67 +10,87 @@ const nodeRequestToRequest = buildToRequest({
   Uint8Array: Uint8Array,
 })
 
-let requestMap = new Map<string, Request>()
-let server: TestServer
+describe('given a test server, buildToRequest()', () => {
+  let requestMap = new Map<string, Request>()
+  let server: TestServer
 
-beforeAll(async () => {
-  server = await runTestServer({
-    handler: async (incoming, response) => {
-      const requestId = incoming.headers['x-request-id']
-      if (typeof requestId !== 'string') {
-        response.writeHead(400)
-        response.end(`Invalid Request Id.`)
-        return
-      }
-
-      const request = nodeRequestToRequest(incoming, { origin: server.url })
-      const [body, readable] = request.body?.tee() ?? []
-      requestMap.set(requestId, new EdgeRuntime.Request(request, { body }))
-      response.writeHead(200, { 'Content-Type': 'text/plain' })
-
-      /**
-       * We respond right away so we can start consuming the body stream in
-       * the test before it has been completely sent, but we still need to
-       * consume the body before completing the server response otherwise
-       * the socket gets closed and we don't get the full body.
-       */
-      const reader = readable?.getReader()
-      if (reader) {
-        while (true) {
-          const { done } = await reader?.read()
-          if (done) break
+  beforeAll(async () => {
+    server = await runTestServer({
+      handler: async (incoming, response) => {
+        const requestId = incoming.headers['x-request-id']
+        if (typeof requestId !== 'string') {
+          response.writeHead(400)
+          response.end(`Invalid Request Id.`)
+          return
         }
-      }
 
-      response.end()
-    },
+        const request = nodeRequestToRequest(incoming, {
+          defaultOrigin: server.url,
+        })
+        const [body, readable] = request.body?.tee() ?? []
+        requestMap.set(requestId, new EdgeRuntime.Request(request, { body }))
+        response.writeHead(200, { 'Content-Type': 'text/plain' })
+
+        /**
+         * We respond right away so we can start consuming the body stream in
+         * the test before it has been completely sent, but we still need to
+         * consume the body before completing the server response otherwise
+         * the socket gets closed and we don't get the full body.
+         */
+        const reader = readable?.getReader()
+        if (reader) {
+          while (true) {
+            const { done } = await reader?.read()
+            if (done) break
+          }
+        }
+
+        response.end()
+      },
+    })
   })
-})
 
-afterAll(() => {
-  return server.close()
-})
+  afterAll(() => {
+    return server.close()
+  })
 
-it('maps the request input', async () => {
-  const input = `${server.url}/hi/there?=foo&bar=baz`
-  const request = await mapRequest(input)
-  expect(request.url).toEqual(input)
-})
+  it('maps the request input', async () => {
+    const input = `${server.url}/hi/there?=foo&bar=baz`
+    const request = await mapRequest(input)
+    expect(request.url).toEqual(input)
+  })
 
-it('maps the request headers`', async () => {
-  const headers = new EdgeRuntime.Headers({ 'x-hi': 'there' })
-  headers.append('vercel-is-awesome', 'true')
-  headers.append('vercel-is-awesome', 'you damn right')
-  const request = await mapRequest(server.url, { headers })
-  expect(request?.headers.get('connection')).toEqual('keep-alive')
-  expect(request?.headers.get('user-agent')).toEqual('undici')
-  expect(request?.headers.get('x-hi')).toEqual(headers.get('x-hi'))
-  expect(request?.headers.get('vercel-is-awesome')).toEqual(
-    headers.get('vercel-is-awesome')
-  )
-})
+  it('maps the request headers`', async () => {
+    const headers = new EdgeRuntime.Headers({ 'x-hi': 'there' })
+    headers.append('vercel-is-awesome', 'true')
+    headers.append('vercel-is-awesome', 'you damn right')
+    const request = await mapRequest(server.url, { headers })
+    expect(request?.headers.get('connection')).toEqual('keep-alive')
+    expect(request?.headers.get('user-agent')).toEqual('undici')
+    expect(request?.headers.get('x-hi')).toEqual(headers.get('x-hi'))
+    expect(request?.headers.get('vercel-is-awesome')).toEqual(
+      headers.get('vercel-is-awesome')
+    )
+  })
 
-describe('maps the request body', () => {
+  it(`uses default origin as request url origin when there are no host header`, async () => {
+    const request = await mapRequest(server.url)
+    expect(request.url).toEqual(`${server.url}/`)
+  })
+
+  it(`uses request host header as request url origin`, async () => {
+    const host = 'vercel.com'
+    await expect(
+      mapRequest(server.url, { headers: { host } })
+    ).resolves.toHaveProperty('url', `http://${host}/`)
+    await expect(
+      mapRequest(server.url, { headers: { host: `${host}:6000` } })
+    ).resolves.toHaveProperty('url', `http://${host}:6000/`)
+    await expect(
+      mapRequest(server.url, { headers: { host: `${host}:443` } })
+    ).resolves.toHaveProperty('url', `https://${host}/`)
+  })
+
   it('allows to read the body as text', async () => {
     const request = await mapRequest(server.url, {
       body: 'Hello World',
@@ -114,15 +134,15 @@ describe('maps the request body', () => {
       'The body has already been consumed.'
     )
   })
-})
 
-async function mapRequest(input: string, init: RequestInit = {}) {
-  const requestId = EdgeRuntime.crypto.randomUUID()
-  const headers = new EdgeRuntime.Headers(init.headers)
-  headers.set('x-request-id', requestId)
-  const response = await EdgeRuntime.fetch(input, { ...init, headers })
-  const request = requestMap.get(requestId)
-  expect(response.status).toEqual(200)
-  expect(request).not.toBeUndefined()
-  return request!
-}
+  async function mapRequest(input: string, init: RequestInit = {}) {
+    const requestId = EdgeRuntime.crypto.randomUUID()
+    const headers = new EdgeRuntime.Headers(init.headers)
+    headers.set('x-request-id', requestId)
+    const response = await EdgeRuntime.fetch(input, { ...init, headers })
+    const request = requestMap.get(requestId)
+    expect(response.status).toEqual(200)
+    expect(request).not.toBeUndefined()
+    return request!
+  }
+})

--- a/packages/node-utils/test/node-to-edge/request.test.ts
+++ b/packages/node-utils/test/node-to-edge/request.test.ts
@@ -8,141 +8,140 @@ const nodeRequestToRequest = buildToRequest({
   ReadableStream: EdgeRuntime.ReadableStream,
   Request: EdgeRuntime.Request,
   Uint8Array: Uint8Array,
+  FetchEvent: EdgeRuntime.FetchEvent,
 })
 
-describe('given a test server, buildToRequest()', () => {
-  let requestMap = new Map<string, Request>()
-  let server: TestServer
+let requestMap = new Map<string, Request>()
+let server: TestServer
 
-  beforeAll(async () => {
-    server = await runTestServer({
-      handler: async (incoming, response) => {
-        const requestId = incoming.headers['x-request-id']
-        if (typeof requestId !== 'string') {
-          response.writeHead(400)
-          response.end(`Invalid Request Id.`)
-          return
+beforeAll(async () => {
+  server = await runTestServer({
+    handler: async (incoming, response) => {
+      const requestId = incoming.headers['x-request-id']
+      if (typeof requestId !== 'string') {
+        response.writeHead(400)
+        response.end(`Invalid Request Id.`)
+        return
+      }
+
+      const request = nodeRequestToRequest(incoming, {
+        defaultOrigin: server.url,
+      })
+      const [body, readable] = request.body?.tee() ?? []
+      requestMap.set(requestId, new EdgeRuntime.Request(request, { body }))
+      response.writeHead(200, { 'Content-Type': 'text/plain' })
+
+      /**
+       * We respond right away so we can start consuming the body stream in
+       * the test before it has been completely sent, but we still need to
+       * consume the body before completing the server response otherwise
+       * the socket gets closed and we don't get the full body.
+       */
+      const reader = readable?.getReader()
+      if (reader) {
+        while (true) {
+          const { done } = await reader?.read()
+          if (done) break
         }
+      }
 
-        const request = nodeRequestToRequest(incoming, {
-          defaultOrigin: server.url,
-        })
-        const [body, readable] = request.body?.tee() ?? []
-        requestMap.set(requestId, new EdgeRuntime.Request(request, { body }))
-        response.writeHead(200, { 'Content-Type': 'text/plain' })
-
-        /**
-         * We respond right away so we can start consuming the body stream in
-         * the test before it has been completely sent, but we still need to
-         * consume the body before completing the server response otherwise
-         * the socket gets closed and we don't get the full body.
-         */
-        const reader = readable?.getReader()
-        if (reader) {
-          while (true) {
-            const { done } = await reader?.read()
-            if (done) break
-          }
-        }
-
-        response.end()
-      },
-    })
+      response.end()
+    },
   })
-
-  afterAll(() => {
-    return server.close()
-  })
-
-  it('maps the request input', async () => {
-    const input = `${server.url}/hi/there?=foo&bar=baz`
-    const request = await mapRequest(input)
-    expect(request.url).toEqual(input)
-  })
-
-  it('maps the request headers`', async () => {
-    const headers = new EdgeRuntime.Headers({ 'x-hi': 'there' })
-    headers.append('vercel-is-awesome', 'true')
-    headers.append('vercel-is-awesome', 'you damn right')
-    const request = await mapRequest(server.url, { headers })
-    expect(request?.headers.get('connection')).toEqual('keep-alive')
-    expect(request?.headers.get('user-agent')).toEqual('undici')
-    expect(request?.headers.get('x-hi')).toEqual(headers.get('x-hi'))
-    expect(request?.headers.get('vercel-is-awesome')).toEqual(
-      headers.get('vercel-is-awesome')
-    )
-  })
-
-  it(`uses default origin as request url origin when there are no host header`, async () => {
-    const request = await mapRequest(server.url)
-    expect(request.url).toEqual(`${server.url}/`)
-  })
-
-  it(`uses request host header as request url origin`, async () => {
-    const host = 'vercel.com'
-    await expect(
-      mapRequest(server.url, { headers: { host } })
-    ).resolves.toHaveProperty('url', `http://${host}/`)
-    await expect(
-      mapRequest(server.url, { headers: { host: `${host}:6000` } })
-    ).resolves.toHaveProperty('url', `http://${host}:6000/`)
-    await expect(
-      mapRequest(server.url, { headers: { host: `${host}:443` } })
-    ).resolves.toHaveProperty('url', `https://${host}/`)
-  })
-
-  it('allows to read the body as text', async () => {
-    const request = await mapRequest(server.url, {
-      body: 'Hello World',
-      method: 'POST',
-    })
-
-    expect(request.method).toEqual('POST')
-    expect(await request.text()).toEqual('Hello World')
-  })
-
-  it('allows to read the body as chunks', async () => {
-    const encoder = new EdgeRuntime.TextEncoder()
-    const body = new EdgeRuntime.ReadableStream<Uint8Array>({
-      start(controller) {
-        controller.enqueue(encoder.encode('Hello '))
-        setTimeout(() => {
-          controller.enqueue(encoder.encode('World'))
-          controller.close()
-        }, 500)
-      },
-    })
-
-    const request = await mapRequest(server.url, {
-      method: 'POST',
-      body,
-    })
-
-    expect(request.method).toEqual('POST')
-    expect(await request.text()).toEqual('Hello World')
-  })
-
-  it('does not allow to read the body twice', async () => {
-    const request = await mapRequest(server.url, {
-      body: 'Hello World',
-      method: 'POST',
-    })
-
-    expect(request.method).toEqual('POST')
-    expect(await request.text()).toEqual('Hello World')
-    await expect(request.text()).rejects.toThrowError(
-      'The body has already been consumed.'
-    )
-  })
-
-  async function mapRequest(input: string, init: RequestInit = {}) {
-    const requestId = EdgeRuntime.crypto.randomUUID()
-    const headers = new EdgeRuntime.Headers(init.headers)
-    headers.set('x-request-id', requestId)
-    const response = await EdgeRuntime.fetch(input, { ...init, headers })
-    const request = requestMap.get(requestId)
-    expect(response.status).toEqual(200)
-    expect(request).not.toBeUndefined()
-    return request!
-  }
 })
+
+afterAll(() => {
+  return server.close()
+})
+
+it('maps the request input', async () => {
+  const input = `${server.url}/hi/there?=foo&bar=baz`
+  const request = await mapRequest(input)
+  expect(request.url).toEqual(input)
+})
+
+it('maps the request headers`', async () => {
+  const headers = new EdgeRuntime.Headers({ 'x-hi': 'there' })
+  headers.append('vercel-is-awesome', 'true')
+  headers.append('vercel-is-awesome', 'you damn right')
+  const request = await mapRequest(server.url, { headers })
+  expect(request?.headers.get('connection')).toEqual('keep-alive')
+  expect(request?.headers.get('user-agent')).toEqual('undici')
+  expect(request?.headers.get('x-hi')).toEqual(headers.get('x-hi'))
+  expect(request?.headers.get('vercel-is-awesome')).toEqual(
+    headers.get('vercel-is-awesome')
+  )
+})
+
+it(`uses default origin as request url origin when there are no host header`, async () => {
+  const request = await mapRequest(server.url)
+  expect(request.url).toEqual(`${server.url}/`)
+})
+
+it(`uses request host header as request url origin`, async () => {
+  const host = 'vercel.com'
+  await expect(
+    mapRequest(server.url, { headers: { host } })
+  ).resolves.toHaveProperty('url', `http://${host}/`)
+  await expect(
+    mapRequest(server.url, { headers: { host: `${host}:6000` } })
+  ).resolves.toHaveProperty('url', `http://${host}:6000/`)
+  await expect(
+    mapRequest(server.url, { headers: { host: `${host}:443` } })
+  ).resolves.toHaveProperty('url', `https://${host}/`)
+})
+
+it('allows to read the body as text', async () => {
+  const request = await mapRequest(server.url, {
+    body: 'Hello World',
+    method: 'POST',
+  })
+
+  expect(request.method).toEqual('POST')
+  expect(await request.text()).toEqual('Hello World')
+})
+
+it('allows to read the body as chunks', async () => {
+  const encoder = new EdgeRuntime.TextEncoder()
+  const body = new EdgeRuntime.ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode('Hello '))
+      setTimeout(() => {
+        controller.enqueue(encoder.encode('World'))
+        controller.close()
+      }, 500)
+    },
+  })
+
+  const request = await mapRequest(server.url, {
+    method: 'POST',
+    body,
+  })
+
+  expect(request.method).toEqual('POST')
+  expect(await request.text()).toEqual('Hello World')
+})
+
+it('does not allow to read the body twice', async () => {
+  const request = await mapRequest(server.url, {
+    body: 'Hello World',
+    method: 'POST',
+  })
+
+  expect(request.method).toEqual('POST')
+  expect(await request.text()).toEqual('Hello World')
+  await expect(request.text()).rejects.toThrowError(
+    'The body has already been consumed.'
+  )
+})
+
+async function mapRequest(input: string, init: RequestInit = {}) {
+  const requestId = EdgeRuntime.crypto.randomUUID()
+  const headers = new EdgeRuntime.Headers(init.headers)
+  headers.set('x-request-id', requestId)
+  const response = await EdgeRuntime.fetch(input, { ...init, headers })
+  const request = requestMap.get(requestId)
+  expect(response.status).toEqual(200)
+  expect(request).not.toBeUndefined()
+  return request!
+}

--- a/packages/node-utils/test/test-utils/run-test-server.ts
+++ b/packages/node-utils/test/test-utils/run-test-server.ts
@@ -21,7 +21,20 @@ export interface TestServer {
 export async function runTestServer(
   options: ServerOptions
 ): Promise<TestServer> {
-  const server = createServer(options.handler)
+  const server = createServer((req, res) => {
+    try {
+      const result = options.handler(req, res)
+      if (result?.catch) {
+        result.catch((error) => {
+          res.statusCode = 500
+          res.end(error.toString())
+        })
+      }
+    } catch (error) {
+      res.statusCode = 500
+      res.end(error?.toString())
+    }
+  })
   const url = await listen(server)
   return {
     close: getKillServer(server),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
       esbuild: 0.17.4
       finepack: latest
       git-authors-cli: latest
-      jest: 29.4.0
+      jest: 29.3.1
       jest-watch-typeahead: 2.2.1
       nano-staged: latest
       prettier: latest
@@ -32,12 +32,12 @@ importers:
       esbuild: 0.17.4
       finepack: 2.10.15
       git-authors-cli: 1.0.45
-      jest: 29.4.0_4f2ldd7um3b3u4eyvetyqsphze
-      jest-watch-typeahead: 2.2.1_jest@29.4.0
+      jest: 29.3.1_4f2ldd7um3b3u4eyvetyqsphze
+      jest-watch-typeahead: 2.2.1_jest@29.3.1
       nano-staged: 0.8.0
       prettier: 2.8.3
       simple-git-hooks: 2.8.1
-      ts-jest: 29.0.5_4rbbsuegxgizcahsqjbulrgqyq
+      ts-jest: 29.0.5_f6moou735nhgqh2og2bhnoem4a
       ts-node: 10.9.1_6yr256pmli274zrjafonbeyefq
       turbo: 1.7.0
       typescript: 4.9.4
@@ -257,7 +257,7 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       '@jridgewell/gen-mapping': 0.1.1
-      '@jridgewell/trace-mapping': 0.3.15
+      '@jridgewell/trace-mapping': 0.3.17
 
   /@babel/code-frame/7.18.6:
     resolution: {integrity: sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==}
@@ -283,7 +283,7 @@ packages:
       '@babel/template': 7.18.10
       '@babel/traverse': 7.18.11
       '@babel/types': 7.18.10
-      convert-source-map: 1.8.0
+      convert-source-map: 1.9.0
       debug: 4.3.4
       gensync: 1.0.0-beta.2
       json5: 2.2.3
@@ -342,7 +342,7 @@ packages:
       '@babel/helper-module-imports': 7.18.6
       '@babel/helper-simple-access': 7.18.6
       '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/helper-validator-identifier': 7.18.6
+      '@babel/helper-validator-identifier': 7.19.1
       '@babel/template': 7.18.10
       '@babel/traverse': 7.18.11
       '@babel/types': 7.18.10
@@ -369,8 +369,8 @@ packages:
     resolution: {integrity: sha512-XtIfWmeNY3i4t7t4D2t02q50HvqHybPqW2ki1kosnvWCwuCMeo81Jf0gwr85jy/neUdg5XDdeFE/80DXiO+njw==}
     engines: {node: '>=6.9.0'}
 
-  /@babel/helper-validator-identifier/7.18.6:
-    resolution: {integrity: sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==}
+  /@babel/helper-validator-identifier/7.19.1:
+    resolution: {integrity: sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==}
     engines: {node: '>=6.9.0'}
 
   /@babel/helper-validator-option/7.18.6:
@@ -391,7 +391,7 @@ packages:
     resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-validator-identifier': 7.18.6
+      '@babel/helper-validator-identifier': 7.19.1
       chalk: 2.4.2
       js-tokens: 4.0.0
 
@@ -518,8 +518,8 @@ packages:
       '@babel/core': 7.18.10
       '@babel/helper-plugin-utils': 7.18.9
 
-  /@babel/runtime/7.20.6:
-    resolution: {integrity: sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==}
+  /@babel/runtime/7.20.13:
+    resolution: {integrity: sha512-gt3PKXs0DBoL9xCvOIIZ2NEqAGZqHjAnmVbfQtB620V0uReIQutpel14KcneZuer7UioY8ALKZ7iocavvzTNFA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.13.11
@@ -554,7 +554,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-string-parser': 7.18.10
-      '@babel/helper-validator-identifier': 7.18.6
+      '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
 
   /@bcoe/v8-coverage/0.2.3:
@@ -564,7 +564,7 @@ packages:
   /@changesets/apply-release-plan/6.1.3:
     resolution: {integrity: sha512-ECDNeoc3nfeAe1jqJb5aFQX7CqzQhD2klXRez2JDb/aVpGUbX673HgKrnrgJRuQR/9f2TtLoYIzrGB9qwD77mg==}
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.20.13
       '@changesets/config': 2.3.0
       '@changesets/get-version-range-type': 0.3.2
       '@changesets/git': 2.0.0
@@ -582,7 +582,7 @@ packages:
   /@changesets/assemble-release-plan/5.2.3:
     resolution: {integrity: sha512-g7EVZCmnWz3zMBAdrcKhid4hkHT+Ft1n0mLussFMcB1dE2zCuwcvGoy9ec3yOgPGF4hoMtgHaMIk3T3TBdvU9g==}
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.20.13
       '@changesets/errors': 0.1.4
       '@changesets/get-dependents-graph': 1.3.5
       '@changesets/types': 5.2.1
@@ -600,7 +600,7 @@ packages:
     resolution: {integrity: sha512-0cbTiDms+ICTVtEwAFLNW0jBNex9f5+fFv3I771nBvdnV/mOjd1QJ4+f8KtVSOrwD9SJkk9xbDkWFb0oXd8d1Q==}
     hasBin: true
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.20.13
       '@changesets/apply-release-plan': 6.1.3
       '@changesets/assemble-release-plan': 5.2.3
       '@changesets/changelog-git': 0.1.14
@@ -667,7 +667,7 @@ packages:
     resolution: {integrity: sha512-JppheLu7S114aEs157fOZDjFqUDpm7eHdq5E8SSR0gUBTEK0cNSHsrSR5a66xs0z3RWuo46QvA3vawp8BxDHvg==}
     dependencies:
       dataloader: 1.4.0
-      node-fetch: 2.6.7
+      node-fetch: 2.6.8
     transitivePeerDependencies:
       - encoding
     dev: true
@@ -675,7 +675,7 @@ packages:
   /@changesets/get-release-plan/3.0.16:
     resolution: {integrity: sha512-OpP9QILpBp1bY2YNIKFzwigKh7Qe9KizRsZomzLe6pK8IUo8onkAAVUD8+JRKSr8R7d4+JRuQrfSSNlEwKyPYg==}
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.20.13
       '@changesets/assemble-release-plan': 5.2.3
       '@changesets/config': 2.3.0
       '@changesets/pre': 1.0.14
@@ -691,7 +691,7 @@ packages:
   /@changesets/git/2.0.0:
     resolution: {integrity: sha512-enUVEWbiqUTxqSnmesyJGWfzd51PY4H7mH9yUw0hPVpZBJ6tQZFMU3F3mT/t9OJ/GjyiM4770i+sehAn6ymx6A==}
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.20.13
       '@changesets/errors': 0.1.4
       '@changesets/types': 5.2.1
       '@manypkg/get-packages': 1.1.3
@@ -716,7 +716,7 @@ packages:
   /@changesets/pre/1.0.14:
     resolution: {integrity: sha512-dTsHmxQWEQekHYHbg+M1mDVYFvegDh9j/kySNuDKdylwfMEevTeDouR7IfHNyVodxZXu17sXoJuf2D0vi55FHQ==}
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.20.13
       '@changesets/errors': 0.1.4
       '@changesets/types': 5.2.1
       '@manypkg/get-packages': 1.1.3
@@ -726,7 +726,7 @@ packages:
   /@changesets/read/0.5.9:
     resolution: {integrity: sha512-T8BJ6JS6j1gfO1HFq50kU3qawYxa4NTbI/ASNVVCBTsKquy2HYwM9r7ZnzkiMe8IEObAJtUVGSrePCOxAK2haQ==}
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.20.13
       '@changesets/git': 2.0.0
       '@changesets/logger': 0.0.5
       '@changesets/parse': 0.3.16
@@ -747,7 +747,7 @@ packages:
   /@changesets/write/0.2.3:
     resolution: {integrity: sha512-Dbamr7AIMvslKnNYsLFafaVORx4H0pvCA2MHqgtNCySMe1blImEyAEOzDmcgKAkgz4+uwoLz7demIrX+JBr/Xw==}
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.20.13
       '@changesets/types': 5.2.1
       fs-extra: 7.0.1
       human-id: 1.0.2
@@ -1010,8 +1010,8 @@ packages:
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
 
-  /@jest/console/29.4.0:
-    resolution: {integrity: sha512-xpXud7e/8zo4syxQlAMDz+EQiFsf8/zXDPslBYm+UaSJ5uGTKQHhbSHfECp7Fw1trQtopjYumeved0n3waijhQ==}
+  /@jest/console/29.3.1:
+    resolution: {integrity: sha512-IRE6GD47KwcqA09RIWrabKdHPiKDGgtAL31xDxbi/RjQMsr+lY+ppxmHwY0dUEV3qvvxZzoe5Hl0RXZJOjQNUg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.4.0
@@ -1022,8 +1022,8 @@ packages:
       slash: 3.0.0
     dev: true
 
-  /@jest/core/29.4.0_ts-node@10.9.1:
-    resolution: {integrity: sha512-E7oCMcENobBFwQXYjnN2IsuUSpRo5jSv7VYk6O9GyQ5kVAfVSS8819I4W5iCCYvqD6+1TzyzLpeEdZEik81kNw==}
+  /@jest/core/29.3.1_ts-node@10.9.1:
+    resolution: {integrity: sha512-0ohVjjRex985w5MmO5L3u5GR1O30DexhBSpuwx2P+9ftyqHdJXnk7IUWiP80oHMvt7ubHCJHxV0a0vlKVuZirw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
       node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
@@ -1031,30 +1031,30 @@ packages:
       node-notifier:
         optional: true
     dependencies:
-      '@jest/console': 29.4.0
-      '@jest/reporters': 29.4.0
-      '@jest/test-result': 29.4.0
-      '@jest/transform': 29.4.0
+      '@jest/console': 29.3.1
+      '@jest/reporters': 29.3.1
+      '@jest/test-result': 29.3.1
+      '@jest/transform': 29.3.1
       '@jest/types': 29.4.0
       '@types/node': 18.7.14
       ansi-escapes: 4.3.2
       chalk: 4.1.2
-      ci-info: 3.3.2
+      ci-info: 3.7.1
       exit: 0.1.2
       graceful-fs: 4.2.10
-      jest-changed-files: 29.4.0
-      jest-config: 29.4.0_gsb7asu77en4txj3es3i65pxci
-      jest-haste-map: 29.4.0
+      jest-changed-files: 29.2.0
+      jest-config: 29.3.1_gsb7asu77en4txj3es3i65pxci
+      jest-haste-map: 29.3.1
       jest-message-util: 29.4.0
       jest-regex-util: 29.2.0
-      jest-resolve: 29.4.0
-      jest-resolve-dependencies: 29.4.0
-      jest-runner: 29.4.0
-      jest-runtime: 29.4.0
-      jest-snapshot: 29.4.0
+      jest-resolve: 29.3.1
+      jest-resolve-dependencies: 29.3.1
+      jest-runner: 29.3.1
+      jest-runtime: 29.3.1
+      jest-snapshot: 29.3.1
       jest-util: 29.4.0
-      jest-validate: 29.4.0
-      jest-watcher: 29.4.0
+      jest-validate: 29.3.1
+      jest-watcher: 29.3.1
       micromatch: 4.0.5
       pretty-format: 29.4.0
       slash: 3.0.0
@@ -1074,14 +1074,14 @@ packages:
       jest-mock: 28.1.3
     dev: false
 
-  /@jest/environment/29.4.0:
-    resolution: {integrity: sha512-ocl1VGDcZHfHnYLTqkBY7yXme1bF4x0BevJ9wb6y0sLOSyBCpp8L5fEASChB+wU53WMrIK6kBfGt+ZYoM2kcdw==}
+  /@jest/environment/29.3.1:
+    resolution: {integrity: sha512-pMmvfOPmoa1c1QpfFW0nXYtNLpofqo4BrCIk6f2kW4JFeNlHV2t3vd+3iDLf31e2ot2Mec0uqZfmI+U0K2CFag==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/fake-timers': 29.4.0
+      '@jest/fake-timers': 29.3.1
       '@jest/types': 29.4.0
       '@types/node': 18.7.14
-      jest-mock: 29.4.0
+      jest-mock: 29.3.1
     dev: true
 
   /@jest/expect-utils/28.1.3:
@@ -1115,12 +1115,12 @@ packages:
       - supports-color
     dev: false
 
-  /@jest/expect/29.4.0:
-    resolution: {integrity: sha512-IiDZYQ/Oi94aBT0nKKKRvNsB5JTyHoGb+G3SiGoDxz90JfL7SLx/z5IjB0fzBRzy7aLFQOCbVJlaC2fIgU6Y9Q==}
+  /@jest/expect/29.3.1:
+    resolution: {integrity: sha512-QivM7GlSHSsIAWzgfyP8dgeExPRZ9BIe2LsdPyEhCGkZkoyA+kGsoIzbKAfZCvvRzfZioKwPtCZIt5SaoxYCvg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       expect: 29.4.0
-      jest-snapshot: 29.4.0
+      jest-snapshot: 29.3.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1137,15 +1137,15 @@ packages:
       jest-util: 28.1.3
     dev: false
 
-  /@jest/fake-timers/29.4.0:
-    resolution: {integrity: sha512-8sitzN2QrhDwEwH3kKcMMgrv/UIkmm9AUgHixmn4L++GQ0CqVTIztm3YmaIQooLmW3O4GhizNTTCyq3iLbWcMw==}
+  /@jest/fake-timers/29.3.1:
+    resolution: {integrity: sha512-iHTL/XpnDlFki9Tq0Q1GGuVeQ8BHZGIYsvCO5eN/O/oJaRzofG9Xndd9HuSDBI/0ZS79pg0iwn07OMTQ7ngF2A==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.4.0
-      '@sinonjs/fake-timers': 10.0.2
+      '@sinonjs/fake-timers': 9.1.2
       '@types/node': 18.7.14
       jest-message-util: 29.4.0
-      jest-mock: 29.4.0
+      jest-mock: 29.3.1
       jest-util: 29.4.0
     dev: true
 
@@ -1160,20 +1160,20 @@ packages:
       - supports-color
     dev: false
 
-  /@jest/globals/29.4.0:
-    resolution: {integrity: sha512-Q64ZRgGMVL40RcYTfD2GvyjK7vJLPSIvi8Yp3usGPNPQ3SCW+UCY9KEH6+sVtBo8LzhcjtCXuZEd7avnj/T0mQ==}
+  /@jest/globals/29.3.1:
+    resolution: {integrity: sha512-cTicd134vOcwO59OPaB6AmdHQMCtWOe+/DitpTZVxWgMJ+YvXL1HNAmPyiGbSHmF/mXVBkvlm8YYtQhyHPnV6Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/environment': 29.4.0
-      '@jest/expect': 29.4.0
+      '@jest/environment': 29.3.1
+      '@jest/expect': 29.3.1
       '@jest/types': 29.4.0
-      jest-mock: 29.4.0
+      jest-mock: 29.3.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@jest/reporters/29.4.0:
-    resolution: {integrity: sha512-FjJwrD1XOQq/AXKrvnOSf0RgAs6ziUuGKx8+/R53Jscc629JIhg7/m241gf1shUm/fKKxoHd7aCexcg7kxvkWQ==}
+  /@jest/reporters/29.3.1:
+    resolution: {integrity: sha512-GhBu3YFuDrcAYW/UESz1JphEAbvUjaY2vShRZRoRY1mxpCMB3yGSJ4j9n0GxVlEOdCf7qjvUfBCrTUUqhVfbRA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
       node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
@@ -1182,11 +1182,11 @@ packages:
         optional: true
     dependencies:
       '@bcoe/v8-coverage': 0.2.3
-      '@jest/console': 29.4.0
-      '@jest/test-result': 29.4.0
-      '@jest/transform': 29.4.0
+      '@jest/console': 29.3.1
+      '@jest/test-result': 29.3.1
+      '@jest/transform': 29.3.1
       '@jest/types': 29.4.0
-      '@jridgewell/trace-mapping': 0.3.15
+      '@jridgewell/trace-mapping': 0.3.17
       '@types/node': 18.7.14
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
@@ -1197,10 +1197,10 @@ packages:
       istanbul-lib-instrument: 5.2.0
       istanbul-lib-report: 3.0.0
       istanbul-lib-source-maps: 4.0.1
-      istanbul-reports: 3.1.4
+      istanbul-reports: 3.1.5
       jest-message-util: 29.4.0
       jest-util: 29.4.0
-      jest-worker: 29.4.0
+      jest-worker: 29.3.1
       slash: 3.0.0
       string-length: 4.0.2
       strip-ansi: 6.0.1
@@ -1234,7 +1234,7 @@ packages:
     resolution: {integrity: sha512-1NX9/7zzI0nqa6+kgpSdKPK+WU1p+SJk3TloWZf5MzPbxri9UEeXX5bWZAPCzbQcyuAzubcdUHA7hcNznmRqWQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.15
+      '@jridgewell/trace-mapping': 0.3.17
       callsites: 3.1.0
       graceful-fs: 4.2.10
     dev: true
@@ -1243,29 +1243,19 @@ packages:
     resolution: {integrity: sha512-qeLa6qc0ddB0kuOZyZIhfN5q0e2htngokyTWsGriedsDhItisW7SDYZ7ceOe57Ii03sL988/03wAcBh3TChMGw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/console': 29.4.0
+      '@jest/console': 29.3.1
       '@jest/types': 29.4.0
       '@types/istanbul-lib-coverage': 2.0.4
       collect-v8-coverage: 1.0.1
     dev: true
 
-  /@jest/test-result/29.4.0:
-    resolution: {integrity: sha512-EtRklzjpddZU/aBVxJqqejfzfOcnehmjNXufs6u6qwd05kkhXpAPhZdt8bLlQd7cA2nD+JqZQ5Dx9NX5Jh6mjA==}
+  /@jest/test-sequencer/29.3.1:
+    resolution: {integrity: sha512-IqYvLbieTv20ArgKoAMyhLHNrVHJfzO6ARZAbQRlY4UGWfdDnLlZEF0BvKOMd77uIiIjSZRwq3Jb3Fa3I8+2UA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/console': 29.4.0
-      '@jest/types': 29.4.0
-      '@types/istanbul-lib-coverage': 2.0.4
-      collect-v8-coverage: 1.0.1
-    dev: true
-
-  /@jest/test-sequencer/29.4.0:
-    resolution: {integrity: sha512-pEwIgdfvEgF2lBOYX3DVn3SrvsAZ9FXCHw7+C6Qz87HnoDGQwbAselhWLhpgbxDjs6RC9QUJpFnrLmM5uwZV+g==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@jest/test-result': 29.4.0
+      '@jest/test-result': 29.3.1
       graceful-fs: 4.2.10
-      jest-haste-map: 29.4.0
+      jest-haste-map: 29.3.1
       slash: 3.0.0
     dev: true
 
@@ -1275,10 +1265,10 @@ packages:
     dependencies:
       '@babel/core': 7.18.10
       '@jest/types': 28.1.3
-      '@jridgewell/trace-mapping': 0.3.15
+      '@jridgewell/trace-mapping': 0.3.17
       babel-plugin-istanbul: 6.1.1
       chalk: 4.1.2
-      convert-source-map: 1.8.0
+      convert-source-map: 1.9.0
       fast-json-stable-stringify: 2.1.0
       graceful-fs: 4.2.10
       jest-haste-map: 28.1.3
@@ -1287,30 +1277,30 @@ packages:
       micromatch: 4.0.5
       pirates: 4.0.5
       slash: 3.0.0
-      write-file-atomic: 4.0.1
+      write-file-atomic: 4.0.2
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@jest/transform/29.4.0:
-    resolution: {integrity: sha512-hDjw3jz4GnvbyLMgcFpC9/34QcUhVIzJkBqz7o+3AhgfhGRzGuQppuLf5r/q7lDAAyJ6jzL+SFG7JGsScHOcLQ==}
+  /@jest/transform/29.3.1:
+    resolution: {integrity: sha512-8wmCFBTVGYqFNLWfcOWoVuMuKYPUBTnTMDkdvFtAYELwDOl9RGwOsvQWGPFxDJ8AWY9xM/8xCXdqmPK3+Q5Lug==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@babel/core': 7.18.10
       '@jest/types': 29.4.0
-      '@jridgewell/trace-mapping': 0.3.15
+      '@jridgewell/trace-mapping': 0.3.17
       babel-plugin-istanbul: 6.1.1
       chalk: 4.1.2
       convert-source-map: 2.0.0
       fast-json-stable-stringify: 2.1.0
       graceful-fs: 4.2.10
-      jest-haste-map: 29.4.0
+      jest-haste-map: 29.3.1
       jest-regex-util: 29.2.0
       jest-util: 29.4.0
       micromatch: 4.0.5
       pirates: 4.0.5
       slash: 3.0.0
-      write-file-atomic: 5.0.0
+      write-file-atomic: 4.0.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1332,18 +1322,6 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/schemas': 29.0.0
-      '@types/istanbul-lib-coverage': 2.0.4
-      '@types/istanbul-reports': 3.0.1
-      '@types/node': 18.7.14
-      '@types/yargs': 17.0.11
-      chalk: 4.1.2
-    dev: true
-
-  /@jest/types/29.3.1:
-    resolution: {integrity: sha512-d0S0jmmTpjnhCmNpApgX3jrUZgZ22ivKJRvL2lli5hpCRoNnp1f85r2/wpKfXuYu8E7Jjh1hGfhPyup1NM5AmA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@jest/schemas': 29.4.0
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
       '@types/node': 18.7.14
@@ -1376,7 +1354,7 @@ packages:
     dependencies:
       '@jridgewell/set-array': 1.1.2
       '@jridgewell/sourcemap-codec': 1.4.14
-      '@jridgewell/trace-mapping': 0.3.15
+      '@jridgewell/trace-mapping': 0.3.17
 
   /@jridgewell/resolve-uri/3.1.0:
     resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
@@ -1389,8 +1367,8 @@ packages:
   /@jridgewell/sourcemap-codec/1.4.14:
     resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
 
-  /@jridgewell/trace-mapping/0.3.15:
-    resolution: {integrity: sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==}
+  /@jridgewell/trace-mapping/0.3.17:
+    resolution: {integrity: sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==}
     dependencies:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.14
@@ -1405,7 +1383,7 @@ packages:
   /@manypkg/find-root/1.1.0:
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.20.13
       '@types/node': 12.20.55
       find-up: 4.1.0
       fs-extra: 8.1.0
@@ -1414,7 +1392,7 @@ packages:
   /@manypkg/get-packages/1.1.3:
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.20.13
       '@changesets/types': 4.1.0
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
@@ -1830,7 +1808,7 @@ packages:
     engines: {node: '>= 8'}
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
-      fastq: 1.13.0
+      fastq: 1.15.0
 
   /@peculiar/asn1-schema/2.3.0:
     resolution: {integrity: sha512-DtNLAG4vmDrdSJFPe7rypkcj597chNQL7u+2dBtYo5mh7VW2+im6ke+O0NVr8W1f4re4C3F71LhoMb0Yxqa48Q==}
@@ -1902,25 +1880,11 @@ packages:
     resolution: {integrity: sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==}
     dependencies:
       type-detect: 4.0.8
-    dev: false
-
-  /@sinonjs/commons/2.0.0:
-    resolution: {integrity: sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==}
-    dependencies:
-      type-detect: 4.0.8
-    dev: true
-
-  /@sinonjs/fake-timers/10.0.2:
-    resolution: {integrity: sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==}
-    dependencies:
-      '@sinonjs/commons': 2.0.0
-    dev: true
 
   /@sinonjs/fake-timers/9.1.2:
     resolution: {integrity: sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==}
     dependencies:
       '@sinonjs/commons': 1.8.3
-    dev: false
 
   /@svitejs/changesets-changelog-github-compact/1.1.0:
     resolution: {integrity: sha512-qhUGGDHcpbY2zpjW3SwqchuW8J/5EzlPFud7xNntHKA7f3a/mx5+g+ruJKFHSAiVZYo30PALt+AyhmPUNKH/Og==}
@@ -2037,7 +2001,7 @@ packages:
   /@types/is-ci/3.0.0:
     resolution: {integrity: sha512-Q0Op0hdWbYd1iahB+IFNQcWXFq4O0Q5MwQP7uN0souuQ4rPg1vEYcnIOfr1gY+M+6rc8FGoRaBO1mOOvL29sEQ==}
     dependencies:
-      ci-info: 3.3.2
+      ci-info: 3.7.1
     dev: true
 
   /@types/istanbul-lib-coverage/2.0.4:
@@ -2354,13 +2318,13 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /array.prototype.flat/1.3.0:
-    resolution: {integrity: sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==}
+  /array.prototype.flat/1.3.1:
+    resolution: {integrity: sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
-      es-abstract: 1.20.1
+      es-abstract: 1.21.1
       es-shim-unscopables: 1.0.0
     dev: true
 
@@ -2407,6 +2371,11 @@ packages:
       postcss-value-parser: 4.2.0
     dev: true
 
+  /available-typed-arrays/1.0.5:
+    resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
   /axios/1.2.3:
     resolution: {integrity: sha512-pdDkMYJeuXLZ6Xj/Q5J3Phpe+jbGdsSzlQaFVkMQzRUL05+6+tetX8TV3p4HrU4kzuO9bt+io/yGQxuyxA/xcw==}
     dependencies:
@@ -2417,17 +2386,17 @@ packages:
       - debug
     dev: true
 
-  /babel-jest/29.4.0_@babel+core@7.18.10:
-    resolution: {integrity: sha512-M61cGPg4JBashDvIzKoIV/y95mSF6x3ome7CMEaszUTHD4uo6dtC6Nln+fvRTspYNtwy8lDHl5lmoTBSNY/a+g==}
+  /babel-jest/29.3.1_@babel+core@7.18.10:
+    resolution: {integrity: sha512-aard+xnMoxgjwV70t0L6wkW/3HQQtV+O0PEimxKgzNqCJnbYmroPojdP2tqKSOAt8QAKV/uSZU8851M7B5+fcA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
       '@babel/core': ^7.8.0
     dependencies:
       '@babel/core': 7.18.10
-      '@jest/transform': 29.4.0
+      '@jest/transform': 29.3.1
       '@types/babel__core': 7.1.19
       babel-plugin-istanbul: 6.1.1
-      babel-preset-jest: 29.4.0_@babel+core@7.18.10
+      babel-preset-jest: 29.2.0_@babel+core@7.18.10
       chalk: 4.1.2
       graceful-fs: 4.2.10
       slash: 3.0.0
@@ -2447,8 +2416,8 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /babel-plugin-jest-hoist/29.4.0:
-    resolution: {integrity: sha512-a/sZRLQJEmsmejQ2rPEUe35nO1+C9dc9O1gplH1SXmJxveQSRUYdBk8yGZG/VOUuZs1u2aHZJusEGoRMbhhwCg==}
+  /babel-plugin-jest-hoist/29.2.0:
+    resolution: {integrity: sha512-TnspP2WNiR3GLfCsUNHqeXw0RoQ2f9U5hQ5L3XFpwuO8htQmSrhh8qsB6vi5Yi8+kuynN1yjDjQsPfkebmB6ZA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@babel/template': 7.18.10
@@ -2476,14 +2445,14 @@ packages:
       '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.18.10
       '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.18.10
 
-  /babel-preset-jest/29.4.0_@babel+core@7.18.10:
-    resolution: {integrity: sha512-fUB9vZflUSM3dO/6M2TCAepTzvA4VkOvl67PjErcrQMGt9Eve7uazaeyCZ2th3UtI7ljpiBJES0F7A1vBRsLZA==}
+  /babel-preset-jest/29.2.0_@babel+core@7.18.10:
+    resolution: {integrity: sha512-z9JmMJppMxNv8N7fNRHvhMg9cvIkMxQBXgFkane3yKVEvEOP+kB50lk8DFRvF9PGqbyXxlmebKWhuDORO8RgdA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.18.10
-      babel-plugin-jest-hoist: 29.4.0
+      babel-plugin-jest-hoist: 29.2.0
       babel-preset-current-node-syntax: 1.0.1_@babel+core@7.18.10
     dev: true
 
@@ -2612,7 +2581,7 @@ packages:
       foreground-child: 2.0.0
       istanbul-lib-coverage: 3.2.0
       istanbul-lib-report: 3.0.0
-      istanbul-reports: 3.1.4
+      istanbul-reports: 3.1.5
       rimraf: 3.0.2
       test-exclude: 6.0.0
       v8-to-istanbul: 9.0.1
@@ -2642,7 +2611,7 @@ packages:
     resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
     dependencies:
       function-bind: 1.1.1
-      get-intrinsic: 1.1.2
+      get-intrinsic: 1.2.0
     dev: true
 
   /callsites/3.1.0:
@@ -2804,6 +2773,12 @@ packages:
 
   /ci-info/3.3.2:
     resolution: {integrity: sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg==}
+    dev: false
+
+  /ci-info/3.7.1:
+    resolution: {integrity: sha512-4jYS4MOAaCIStSRwiuxc4B8MYhIe676yO1sYGzARnjXkWpmzZMMYxY6zu8WYWDhSuth5zhrQ1rhNSibyyvv4/w==}
+    engines: {node: '>=8'}
+    dev: true
 
   /cjs-module-lexer/1.2.2:
     resolution: {integrity: sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==}
@@ -2835,6 +2810,15 @@ packages:
 
   /cliui/7.0.4:
     resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+    dev: true
+
+  /cliui/8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
     dependencies:
       string-width: 4.2.3
       strip-ansi: 6.0.1
@@ -2933,10 +2917,8 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /convert-source-map/1.8.0:
-    resolution: {integrity: sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==}
-    dependencies:
-      safe-buffer: 5.1.2
+  /convert-source-map/1.9.0:
+    resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
 
   /convert-source-map/2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -3021,8 +3003,8 @@ packages:
     dependencies:
       ms: 2.1.2
 
-  /decamelize-keys/1.1.0:
-    resolution: {integrity: sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==}
+  /decamelize-keys/1.1.1:
+    resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==}
     engines: {node: '>=0.10.0'}
     dependencies:
       decamelize: 1.2.0
@@ -3061,8 +3043,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /defaults/1.0.3:
-    resolution: {integrity: sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==}
+  /defaults/1.0.4:
+    resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
     dependencies:
       clone: 1.0.4
     dev: true
@@ -3122,11 +3104,6 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dev: false
 
-  /diff-sequences/29.2.0:
-    resolution: {integrity: sha512-413SY5JpYeSBZxmenGEmCVQ8mCgtFJF0w9PROdaS6z987XC2Pd2GOKqOITLtMftmyFZqgtCOb/QA7/Z3ZXfzIw==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dev: true
-
   /diff-sequences/29.3.1:
     resolution: {integrity: sha512-hlM3QR272NXCi4pq+N4Kok4kOp6EsgOM3ZSpJI7Da3UAs+Ttsi8MRmB6trM/lhyzUxGfOgnpkHtgqm5Q/CTcfQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -3165,8 +3142,8 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
-  /duplexer3/0.1.4:
-    resolution: {integrity: sha512-CEj8FwwNA4cVH2uFCoHUrmojhYh1vmCdOaneKJXwkeY1i9jnlslVo9dx+hQ5Hl9GnH/Bwy/IjxAyOePyPKYnzA==}
+  /duplexer3/0.1.5:
+    resolution: {integrity: sha512-1A8za6ws41LQgv9HrE/66jyC5yuSjQ3L/KOpFtoBilsAK2iA2wuS5rTt1OCzIvtS2V7nVmedsUU+DGRcjBmOYA==}
     dev: true
 
   /electron-to-chromium/1.4.284:
@@ -3205,33 +3182,52 @@ packages:
       is-arrayish: 0.2.1
     dev: true
 
-  /es-abstract/1.20.1:
-    resolution: {integrity: sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==}
+  /es-abstract/1.21.1:
+    resolution: {integrity: sha512-QudMsPOz86xYz/1dG1OuGBKOELjCh99IIWHLzy5znUB6j8xG2yMA7bfTV86VSqKF+Y/H08vQPR+9jyXpuC6hfg==}
     engines: {node: '>= 0.4'}
     dependencies:
+      available-typed-arrays: 1.0.5
       call-bind: 1.0.2
+      es-set-tostringtag: 2.0.1
       es-to-primitive: 1.2.1
       function-bind: 1.1.1
       function.prototype.name: 1.1.5
-      get-intrinsic: 1.1.2
+      get-intrinsic: 1.2.0
       get-symbol-description: 1.0.0
+      globalthis: 1.0.3
+      gopd: 1.0.1
       has: 1.0.3
       has-property-descriptors: 1.0.0
+      has-proto: 1.0.1
       has-symbols: 1.0.3
-      internal-slot: 1.0.3
-      is-callable: 1.2.4
+      internal-slot: 1.0.4
+      is-array-buffer: 3.0.1
+      is-callable: 1.2.7
       is-negative-zero: 2.0.2
       is-regex: 1.1.4
       is-shared-array-buffer: 1.0.2
       is-string: 1.0.7
+      is-typed-array: 1.1.10
       is-weakref: 1.0.2
-      object-inspect: 1.12.2
+      object-inspect: 1.12.3
       object-keys: 1.1.1
       object.assign: 4.1.4
       regexp.prototype.flags: 1.4.3
-      string.prototype.trimend: 1.0.5
-      string.prototype.trimstart: 1.0.5
+      safe-regex-test: 1.0.0
+      string.prototype.trimend: 1.0.6
+      string.prototype.trimstart: 1.0.6
+      typed-array-length: 1.0.4
       unbox-primitive: 1.0.2
+      which-typed-array: 1.1.9
+    dev: true
+
+  /es-set-tostringtag/2.0.1:
+    resolution: {integrity: sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      get-intrinsic: 1.2.0
+      has: 1.0.3
+      has-tostringtag: 1.0.0
     dev: true
 
   /es-shim-unscopables/1.0.0:
@@ -3244,7 +3240,7 @@ packages:
     resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
     engines: {node: '>= 0.4'}
     dependencies:
-      is-callable: 1.2.4
+      is-callable: 1.2.7
       is-date-object: 1.0.5
       is-symbol: 1.0.4
     dev: true
@@ -3925,8 +3921,8 @@ packages:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
     dev: true
 
-  /fastq/1.13.0:
-    resolution: {integrity: sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==}
+  /fastq/1.15.0:
+    resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==}
     dependencies:
       reusify: 1.0.4
 
@@ -4017,6 +4013,12 @@ packages:
         optional: true
     dev: true
 
+  /for-each/0.3.3:
+    resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
+    dependencies:
+      is-callable: 1.2.7
+    dev: true
+
   /foreground-child/2.0.0:
     resolution: {integrity: sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==}
     engines: {node: '>=8.0.0'}
@@ -4093,7 +4095,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
-      es-abstract: 1.20.1
+      es-abstract: 1.21.1
       functions-have-names: 1.2.3
     dev: true
 
@@ -4110,8 +4112,8 @@ packages:
     engines: {node: 6.* || 8.* || >= 10.*}
     dev: true
 
-  /get-intrinsic/1.1.2:
-    resolution: {integrity: sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==}
+  /get-intrinsic/1.2.0:
+    resolution: {integrity: sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==}
     dependencies:
       function-bind: 1.1.1
       has: 1.0.3
@@ -4156,7 +4158,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.1.2
+      get-intrinsic: 1.2.0
     dev: true
 
   /git-authors-cli/1.0.45:
@@ -4224,8 +4226,8 @@ packages:
       once: 1.4.0
       path-is-absolute: 1.0.1
 
-  /global-dirs/3.0.0:
-    resolution: {integrity: sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==}
+  /global-dirs/3.0.1:
+    resolution: {integrity: sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==}
     engines: {node: '>=10'}
     dependencies:
       ini: 2.0.0
@@ -4235,6 +4237,13 @@ packages:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
 
+  /globalthis/1.0.3:
+    resolution: {integrity: sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      define-properties: 1.1.4
+    dev: true
+
   /globby/11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
@@ -4242,9 +4251,15 @@ packages:
       array-union: 2.1.0
       dir-glob: 3.0.1
       fast-glob: 3.2.12
-      ignore: 5.2.0
+      ignore: 5.2.4
       merge2: 1.4.1
       slash: 3.0.0
+    dev: true
+
+  /gopd/1.0.1:
+    resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
+    dependencies:
+      get-intrinsic: 1.2.0
     dev: true
 
   /got/9.6.0:
@@ -4257,7 +4272,7 @@ packages:
       '@types/responselike': 1.0.0
       cacheable-request: 6.1.0
       decompress-response: 3.3.0
-      duplexer3: 0.1.4
+      duplexer3: 0.1.5
       get-stream: 4.1.0
       lowercase-keys: 1.0.1
       mimic-response: 1.0.1
@@ -4320,7 +4335,12 @@ packages:
   /has-property-descriptors/1.0.0:
     resolution: {integrity: sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==}
     dependencies:
-      get-intrinsic: 1.1.2
+      get-intrinsic: 1.2.0
+    dev: true
+
+  /has-proto/1.0.1:
+    resolution: {integrity: sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==}
+    engines: {node: '>= 0.4'}
     dev: true
 
   /has-symbols/1.0.3:
@@ -4388,11 +4408,11 @@ packages:
       lru-cache: 6.0.0
     dev: true
 
-  /hosted-git-info/5.1.0:
-    resolution: {integrity: sha512-Ek+QmMEqZF8XrbFdwoDjSbm7rT23pCgEMOJmz6GPk/s4yH//RQfNPArhIxbguNxROq/+5lNBwCDHMhA903Kx1Q==}
+  /hosted-git-info/5.2.1:
+    resolution: {integrity: sha512-xIcQYMnhcx2Nr4JTjsFmwwnr9vldugPy9uVm0o87bjqqWMv9GaqsTeT+i99wTl0mk1uLxJtHxLb8kymqTENQsw==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     dependencies:
-      lru-cache: 7.14.0
+      lru-cache: 7.14.1
     dev: true
 
   /html-escaper/2.0.2:
@@ -4424,8 +4444,8 @@ packages:
       safer-buffer: 2.1.2
     dev: true
 
-  /ignore/5.2.0:
-    resolution: {integrity: sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==}
+  /ignore/5.2.4:
+    resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
     engines: {node: '>= 4'}
     dev: true
 
@@ -4481,11 +4501,11 @@ packages:
     resolution: {integrity: sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==}
     dev: false
 
-  /internal-slot/1.0.3:
-    resolution: {integrity: sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==}
+  /internal-slot/1.0.4:
+    resolution: {integrity: sha512-tA8URYccNzMo94s5MQZgH8NB/XTa6HsOo0MLfXTKKEnHVVdegzaQoFZ7Jp44bdvLvY2waT5dc+j5ICEswhi7UQ==}
     engines: {node: '>= 0.4'}
     dependencies:
-      get-intrinsic: 1.1.2
+      get-intrinsic: 1.2.0
       has: 1.0.3
       side-channel: 1.0.4
     dev: true
@@ -4504,6 +4524,14 @@ packages:
       is-alphabetical: 2.0.1
       is-decimal: 2.0.1
     dev: false
+
+  /is-array-buffer/3.0.1:
+    resolution: {integrity: sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==}
+    dependencies:
+      call-bind: 1.0.2
+      get-intrinsic: 1.2.0
+      is-typed-array: 1.1.10
+    dev: true
 
   /is-arrayish/0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
@@ -4535,8 +4563,8 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
-  /is-callable/1.2.4:
-    resolution: {integrity: sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==}
+  /is-callable/1.2.7:
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
     dev: true
 
@@ -4551,11 +4579,11 @@ packages:
     resolution: {integrity: sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==}
     hasBin: true
     dependencies:
-      ci-info: 3.3.2
+      ci-info: 3.7.1
     dev: true
 
-  /is-core-module/2.10.0:
-    resolution: {integrity: sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==}
+  /is-core-module/2.11.0:
+    resolution: {integrity: sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==}
     dependencies:
       has: 1.0.3
     dev: true
@@ -4609,7 +4637,7 @@ packages:
     resolution: {integrity: sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==}
     engines: {node: '>=10'}
     dependencies:
-      global-dirs: 3.0.0
+      global-dirs: 3.0.1
       is-path-inside: 3.0.3
     dev: true
 
@@ -4730,6 +4758,17 @@ packages:
       has-symbols: 1.0.3
     dev: true
 
+  /is-typed-array/1.1.10:
+    resolution: {integrity: sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      available-typed-arrays: 1.0.5
+      call-bind: 1.0.2
+      for-each: 0.3.3
+      gopd: 1.0.1
+      has-tostringtag: 1.0.0
+    dev: true
+
   /is-typedarray/1.0.0:
     resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
     dev: true
@@ -4792,40 +4831,40 @@ packages:
       - supports-color
     dev: true
 
-  /istanbul-reports/3.1.4:
-    resolution: {integrity: sha512-r1/DshN4KSE7xWEknZLLLLDn5CJybV3nw01VTkp6D5jzLuELlcbudfj/eSQFvrKsJuTVCGnePO7ho82Nw9zzfw==}
+  /istanbul-reports/3.1.5:
+    resolution: {integrity: sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==}
     engines: {node: '>=8'}
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.0
     dev: true
 
-  /jest-changed-files/29.4.0:
-    resolution: {integrity: sha512-rnI1oPxgFghoz32Y8eZsGJMjW54UlqT17ycQeCEktcxxwqqKdlj9afl8LNeO0Pbu+h2JQHThQP0BzS67eTRx4w==}
+  /jest-changed-files/29.2.0:
+    resolution: {integrity: sha512-qPVmLLyBmvF5HJrY7krDisx6Voi8DmlV3GZYX0aFNbaQsZeoz1hfxcCMbqDGuQCxU1dJy9eYc2xscE8QrCCYaA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       execa: 5.1.1
       p-limit: 3.1.0
     dev: true
 
-  /jest-circus/29.4.0:
-    resolution: {integrity: sha512-/pFBaCeLzCavRWyz14JwFgpZgPpEZdS6nPnREhczbHl2wy2UezvYcVp5akVFfUmBaA4ThAUp0I8cpgkbuNOm3g==}
+  /jest-circus/29.3.1:
+    resolution: {integrity: sha512-wpr26sEvwb3qQQbdlmei+gzp6yoSSoSL6GsLPxnuayZSMrSd5Ka7IjAvatpIernBvT2+Ic6RLTg+jSebScmasg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/environment': 29.4.0
-      '@jest/expect': 29.4.0
-      '@jest/test-result': 29.4.0
+      '@jest/environment': 29.3.1
+      '@jest/expect': 29.3.1
+      '@jest/test-result': 29.3.1
       '@jest/types': 29.4.0
       '@types/node': 18.7.14
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
       is-generator-fn: 2.1.0
-      jest-each: 29.4.0
+      jest-each: 29.3.1
       jest-matcher-utils: 29.4.0
       jest-message-util: 29.4.0
-      jest-runtime: 29.4.0
-      jest-snapshot: 29.4.0
+      jest-runtime: 29.3.1
+      jest-snapshot: 29.3.1
       jest-util: 29.4.0
       p-limit: 3.1.0
       pretty-format: 29.4.0
@@ -4835,8 +4874,8 @@ packages:
       - supports-color
     dev: true
 
-  /jest-cli/29.4.0_4f2ldd7um3b3u4eyvetyqsphze:
-    resolution: {integrity: sha512-YUkICcxjUd864VOzbfQEi2qd2hIIOd9bRF7LJUNyhWb3Khh3YKrbY0LWwoZZ4WkvukiNdvQu0Z4s6zLsY4hYfg==}
+  /jest-cli/29.3.1_4f2ldd7um3b3u4eyvetyqsphze:
+    resolution: {integrity: sha512-TO/ewvwyvPOiBBuWZ0gm04z3WWP8TIK8acgPzE4IxgsLKQgb377NYGrQLc3Wl/7ndWzIH2CDNNsUjGxwLL43VQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
     peerDependencies:
@@ -4845,26 +4884,26 @@ packages:
       node-notifier:
         optional: true
     dependencies:
-      '@jest/core': 29.4.0_ts-node@10.9.1
-      '@jest/test-result': 29.4.0
+      '@jest/core': 29.3.1_ts-node@10.9.1
+      '@jest/test-result': 29.3.1
       '@jest/types': 29.4.0
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.10
       import-local: 3.1.0
-      jest-config: 29.4.0_4f2ldd7um3b3u4eyvetyqsphze
+      jest-config: 29.3.1_4f2ldd7um3b3u4eyvetyqsphze
       jest-util: 29.4.0
-      jest-validate: 29.4.0
+      jest-validate: 29.3.1
       prompts: 2.4.2
-      yargs: 17.5.1
+      yargs: 17.6.2
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
       - ts-node
     dev: true
 
-  /jest-config/29.4.0_4f2ldd7um3b3u4eyvetyqsphze:
-    resolution: {integrity: sha512-jtgd72nN4Mob4Oego3N/pLRVfR2ui1hv+yO6xR/SUi5G7NtZ/grr95BJ1qRSDYZshuA0Jw57fnttZHZKb04+CA==}
+  /jest-config/29.3.1_4f2ldd7um3b3u4eyvetyqsphze:
+    resolution: {integrity: sha512-y0tFHdj2WnTEhxmGUK1T7fgLen7YK4RtfvpLFBXfQkh2eMJAQq24Vx9472lvn5wg0MAO6B+iPfJfzdR9hJYalg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
       '@types/node': '*'
@@ -4876,23 +4915,23 @@ packages:
         optional: true
     dependencies:
       '@babel/core': 7.18.10
-      '@jest/test-sequencer': 29.4.0
+      '@jest/test-sequencer': 29.3.1
       '@jest/types': 29.4.0
       '@types/node': 14.18.32
-      babel-jest: 29.4.0_@babel+core@7.18.10
+      babel-jest: 29.3.1_@babel+core@7.18.10
       chalk: 4.1.2
-      ci-info: 3.3.2
+      ci-info: 3.7.1
       deepmerge: 4.2.2
       glob: 7.2.3
       graceful-fs: 4.2.10
-      jest-circus: 29.4.0
-      jest-environment-node: 29.4.0
+      jest-circus: 29.3.1
+      jest-environment-node: 29.3.1
       jest-get-type: 29.2.0
       jest-regex-util: 29.2.0
-      jest-resolve: 29.4.0
-      jest-runner: 29.4.0
+      jest-resolve: 29.3.1
+      jest-runner: 29.3.1
       jest-util: 29.4.0
-      jest-validate: 29.4.0
+      jest-validate: 29.3.1
       micromatch: 4.0.5
       parse-json: 5.2.0
       pretty-format: 29.4.0
@@ -4903,8 +4942,8 @@ packages:
       - supports-color
     dev: true
 
-  /jest-config/29.4.0_gsb7asu77en4txj3es3i65pxci:
-    resolution: {integrity: sha512-jtgd72nN4Mob4Oego3N/pLRVfR2ui1hv+yO6xR/SUi5G7NtZ/grr95BJ1qRSDYZshuA0Jw57fnttZHZKb04+CA==}
+  /jest-config/29.3.1_gsb7asu77en4txj3es3i65pxci:
+    resolution: {integrity: sha512-y0tFHdj2WnTEhxmGUK1T7fgLen7YK4RtfvpLFBXfQkh2eMJAQq24Vx9472lvn5wg0MAO6B+iPfJfzdR9hJYalg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
       '@types/node': '*'
@@ -4916,23 +4955,23 @@ packages:
         optional: true
     dependencies:
       '@babel/core': 7.18.10
-      '@jest/test-sequencer': 29.4.0
+      '@jest/test-sequencer': 29.3.1
       '@jest/types': 29.4.0
       '@types/node': 18.7.14
-      babel-jest: 29.4.0_@babel+core@7.18.10
+      babel-jest: 29.3.1_@babel+core@7.18.10
       chalk: 4.1.2
-      ci-info: 3.3.2
+      ci-info: 3.7.1
       deepmerge: 4.2.2
       glob: 7.2.3
       graceful-fs: 4.2.10
-      jest-circus: 29.4.0
-      jest-environment-node: 29.4.0
+      jest-circus: 29.3.1
+      jest-environment-node: 29.3.1
       jest-get-type: 29.2.0
       jest-regex-util: 29.2.0
-      jest-resolve: 29.4.0
-      jest-runner: 29.4.0
+      jest-resolve: 29.3.1
+      jest-runner: 29.3.1
       jest-util: 29.4.0
-      jest-validate: 29.4.0
+      jest-validate: 29.3.1
       micromatch: 4.0.5
       parse-json: 5.2.0
       pretty-format: 29.4.0
@@ -4953,16 +4992,6 @@ packages:
       pretty-format: 28.1.3
     dev: false
 
-  /jest-diff/29.2.1:
-    resolution: {integrity: sha512-gfh/SMNlQmP3MOUgdzxPOd4XETDJifADpT937fN1iUGz+9DgOu2eUPHH25JDkLVcLwwqxv3GzVyK4VBUr9fjfA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      chalk: 4.1.2
-      diff-sequences: 29.2.0
-      jest-get-type: 29.2.0
-      pretty-format: 29.2.1
-    dev: true
-
   /jest-diff/29.4.0:
     resolution: {integrity: sha512-s8KNvFx8YgdQ4fn2YLDQ7N6kmVOP68dUDVJrCHNsTc3UM5jcmyyFeYKL8EPWBQbJ0o0VvDGbWp8oYQ1nsnqnWw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -4980,8 +5009,8 @@ packages:
       detect-newline: 3.1.0
     dev: true
 
-  /jest-each/29.4.0:
-    resolution: {integrity: sha512-LTOvB8JDVFjrwXItyQiyLuDYy5PMApGLLzbfIYR79QLpeohS0bcS6j2HjlWuRGSM8QQQyp+ico59Blv+Jx3fMw==}
+  /jest-each/29.3.1:
+    resolution: {integrity: sha512-qrZH7PmFB9rEzCSl00BWjZYuS1BSOH8lLuC0azQE9lQrAx3PWGKHTDudQiOSwIy5dGAJh7KA0ScYlCP7JxvFYA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.4.0
@@ -4991,15 +5020,15 @@ packages:
       pretty-format: 29.4.0
     dev: true
 
-  /jest-environment-node/29.4.0:
-    resolution: {integrity: sha512-WVveE3fYSH6FhDtZdvXhFKeLsDRItlQgnij+HQv6ZKxTdT1DB5O0sHXKCEC3K5mHraMs1Kzn4ch9jXC7H4L4wA==}
+  /jest-environment-node/29.3.1:
+    resolution: {integrity: sha512-xm2THL18Xf5sIHoU7OThBPtuH6Lerd+Y1NLYiZJlkE3hbE+7N7r8uvHIl/FkZ5ymKXJe/11SQuf3fv4v6rUMag==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/environment': 29.4.0
-      '@jest/fake-timers': 29.4.0
+      '@jest/environment': 29.3.1
+      '@jest/fake-timers': 29.3.1
       '@jest/types': 29.4.0
       '@types/node': 18.7.14
-      jest-mock: 29.4.0
+      jest-mock: 29.3.1
       jest-util: 29.4.0
     dev: true
 
@@ -5032,8 +5061,8 @@ packages:
       fsevents: 2.3.2
     dev: false
 
-  /jest-haste-map/29.4.0:
-    resolution: {integrity: sha512-m/pIEfoK0HoJz4c9bkgS5F9CXN2AM22eaSmUcmqTpadRlNVBOJE2CwkgaUzbrNn5MuAqTV1IPVYwWwjHNnk8eA==}
+  /jest-haste-map/29.3.1:
+    resolution: {integrity: sha512-/FFtvoG1xjbbPXQLFef+WSU4yrc0fc0Dds6aRPBojUid7qlPqZvxdUBA03HW0fnVHXVCnCdkuoghYItKNzc/0A==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.4.0
@@ -5044,15 +5073,15 @@ packages:
       graceful-fs: 4.2.10
       jest-regex-util: 29.2.0
       jest-util: 29.4.0
-      jest-worker: 29.4.0
+      jest-worker: 29.3.1
       micromatch: 4.0.5
       walker: 1.0.8
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
 
-  /jest-leak-detector/29.4.0:
-    resolution: {integrity: sha512-fEGHS6ijzgSv5exABkCecMHNmyHcV52+l39ZsxuwfxmQMp43KBWJn2/Fwg8/l4jTI9uOY9jv8z1dXGgL0PHFjA==}
+  /jest-leak-detector/29.3.1:
+    resolution: {integrity: sha512-3DA/VVXj4zFOPagGkuqHnSQf1GZBmmlagpguxEERO6Pla2g84Q1MaVIB3YMxgUaFIaYag8ZnTyQgiZ35YEqAQA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       jest-get-type: 29.2.0
@@ -5074,9 +5103,9 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       chalk: 4.1.2
-      jest-diff: 29.2.1
+      jest-diff: 29.4.0
       jest-get-type: 29.2.0
-      pretty-format: 29.2.1
+      pretty-format: 29.4.0
     dev: true
 
   /jest-matcher-utils/29.4.0:
@@ -5109,12 +5138,12 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@babel/code-frame': 7.18.6
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.0
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
       graceful-fs: 4.2.10
       micromatch: 4.0.5
-      pretty-format: 29.2.1
+      pretty-format: 29.4.0
       slash: 3.0.0
       stack-utils: 2.0.5
     dev: true
@@ -5142,8 +5171,8 @@ packages:
       '@types/node': 18.7.14
     dev: false
 
-  /jest-mock/29.4.0:
-    resolution: {integrity: sha512-+ShT5i+hcu/OFQRV0f/V/YtwpdFcHg64JZ9A8b40JueP+X9HNrZAYGdkupGIzsUK8AucecxCt4wKauMchxubLQ==}
+  /jest-mock/29.3.1:
+    resolution: {integrity: sha512-H8/qFDtDVMFvFP4X8NuOT3XRDzOUTz+FeACjufHzsOIBAxivLqkB1PoLCaJx9iPPQ8dZThHPp/G3WRWyMgA3JA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.4.0
@@ -5151,7 +5180,7 @@ packages:
       jest-util: 29.4.0
     dev: true
 
-  /jest-pnp-resolver/1.2.2_jest-resolve@29.4.0:
+  /jest-pnp-resolver/1.2.2_jest-resolve@29.3.1:
     resolution: {integrity: sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==}
     engines: {node: '>=6'}
     peerDependencies:
@@ -5160,7 +5189,7 @@ packages:
       jest-resolve:
         optional: true
     dependencies:
-      jest-resolve: 29.4.0
+      jest-resolve: 29.3.1
     dev: true
 
   /jest-regex-util/28.0.2:
@@ -5173,70 +5202,70 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dev: true
 
-  /jest-resolve-dependencies/29.4.0:
-    resolution: {integrity: sha512-hxfC84trREyULSj1Cm+fMjnudrrI2dVQ04COjZRcjCZ97boJlPtfJ+qrl/pN7YXS2fnu3wTHEc3LO094pngL6A==}
+  /jest-resolve-dependencies/29.3.1:
+    resolution: {integrity: sha512-Vk0cYq0byRw2WluNmNWGqPeRnZ3p3hHmjJMp2dyyZeYIfiBskwq4rpiuGFR6QGAdbj58WC7HN4hQHjf2mpvrLA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       jest-regex-util: 29.2.0
-      jest-snapshot: 29.4.0
+      jest-snapshot: 29.3.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /jest-resolve/29.4.0:
-    resolution: {integrity: sha512-g7k7l53T+uC9Dp1mbHyDNkcCt0PMku6Wcfpr1kcMLwOHmM3vucKjSM5+DSa1r4vlDZojh8XH039J3z4FKmtTSw==}
+  /jest-resolve/29.3.1:
+    resolution: {integrity: sha512-amXJgH/Ng712w3Uz5gqzFBBjxV8WFLSmNjoreBGMqxgCz5cH7swmBZzgBaCIOsvb0NbpJ0vgaSFdJqMdT+rADw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       chalk: 4.1.2
       graceful-fs: 4.2.10
-      jest-haste-map: 29.4.0
-      jest-pnp-resolver: 1.2.2_jest-resolve@29.4.0
+      jest-haste-map: 29.3.1
+      jest-pnp-resolver: 1.2.2_jest-resolve@29.3.1
       jest-util: 29.4.0
-      jest-validate: 29.4.0
+      jest-validate: 29.3.1
       resolve: 1.22.1
-      resolve.exports: 2.0.0
+      resolve.exports: 1.1.1
       slash: 3.0.0
     dev: true
 
-  /jest-runner/29.4.0:
-    resolution: {integrity: sha512-4zpcv0NOiJleqT0NAs8YcVbK8MhVRc58CBBn9b0Exc8VPU9GKI+DbzDUZqJYdkJhJSZFy2862l/F6hAqIow1hg==}
+  /jest-runner/29.3.1:
+    resolution: {integrity: sha512-oFvcwRNrKMtE6u9+AQPMATxFcTySyKfLhvso7Sdk/rNpbhg4g2GAGCopiInk1OP4q6gz3n6MajW4+fnHWlU3bA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/console': 29.4.0
-      '@jest/environment': 29.4.0
-      '@jest/test-result': 29.4.0
-      '@jest/transform': 29.4.0
+      '@jest/console': 29.3.1
+      '@jest/environment': 29.3.1
+      '@jest/test-result': 29.3.1
+      '@jest/transform': 29.3.1
       '@jest/types': 29.4.0
       '@types/node': 18.7.14
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.10
       jest-docblock: 29.2.0
-      jest-environment-node: 29.4.0
-      jest-haste-map: 29.4.0
-      jest-leak-detector: 29.4.0
+      jest-environment-node: 29.3.1
+      jest-haste-map: 29.3.1
+      jest-leak-detector: 29.3.1
       jest-message-util: 29.4.0
-      jest-resolve: 29.4.0
-      jest-runtime: 29.4.0
+      jest-resolve: 29.3.1
+      jest-runtime: 29.3.1
       jest-util: 29.4.0
-      jest-watcher: 29.4.0
-      jest-worker: 29.4.0
+      jest-watcher: 29.3.1
+      jest-worker: 29.3.1
       p-limit: 3.1.0
       source-map-support: 0.5.13
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /jest-runtime/29.4.0:
-    resolution: {integrity: sha512-2zumwaGXsIuSF92Ui5Pn5hZV9r7AHMclfBLikrXSq87/lHea9anQ+mC+Cjz/DYTbf/JMjlK1sjZRh8K3yYNvWg==}
+  /jest-runtime/29.3.1:
+    resolution: {integrity: sha512-jLzkIxIqXwBEOZx7wx9OO9sxoZmgT2NhmQKzHQm1xwR1kNW/dn0OjxR424VwHHf1SPN6Qwlb5pp1oGCeFTQ62A==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/environment': 29.4.0
-      '@jest/fake-timers': 29.4.0
-      '@jest/globals': 29.4.0
+      '@jest/environment': 29.3.1
+      '@jest/fake-timers': 29.3.1
+      '@jest/globals': 29.3.1
       '@jest/source-map': 29.2.0
-      '@jest/test-result': 29.4.0
-      '@jest/transform': 29.4.0
+      '@jest/test-result': 29.3.1
+      '@jest/transform': 29.3.1
       '@jest/types': 29.4.0
       '@types/node': 18.7.14
       chalk: 4.1.2
@@ -5244,14 +5273,13 @@ packages:
       collect-v8-coverage: 1.0.1
       glob: 7.2.3
       graceful-fs: 4.2.10
-      jest-haste-map: 29.4.0
+      jest-haste-map: 29.3.1
       jest-message-util: 29.4.0
-      jest-mock: 29.4.0
+      jest-mock: 29.3.1
       jest-regex-util: 29.2.0
-      jest-resolve: 29.4.0
-      jest-snapshot: 29.4.0
+      jest-resolve: 29.3.1
+      jest-snapshot: 29.3.1
       jest-util: 29.4.0
-      semver: 7.3.7
       slash: 3.0.0
       strip-bom: 4.0.0
     transitivePeerDependencies:
@@ -5284,13 +5312,13 @@ packages:
       jest-util: 28.1.3
       natural-compare: 1.4.0
       pretty-format: 28.1.3
-      semver: 7.3.7
+      semver: 7.3.8
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /jest-snapshot/29.4.0:
-    resolution: {integrity: sha512-UnK3MhdEWrQ2J6MnlKe51tvN5FjRUBQnO4m1LPlDx61or3w9+cP/U0x9eicutgunu/QzE4WC82jj6CiGIAFYzw==}
+  /jest-snapshot/29.3.1:
+    resolution: {integrity: sha512-+3JOc+s28upYLI2OJM4PWRGK9AgpsMs/ekNryUV0yMBClT9B1DF2u2qay8YxcQd338PPYSFNb0lsar1B49sLDA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@babel/core': 7.18.10
@@ -5300,7 +5328,7 @@ packages:
       '@babel/traverse': 7.18.11
       '@babel/types': 7.18.10
       '@jest/expect-utils': 29.4.0
-      '@jest/transform': 29.4.0
+      '@jest/transform': 29.3.1
       '@jest/types': 29.4.0
       '@types/babel__traverse': 7.18.0
       '@types/prettier': 2.7.0
@@ -5310,13 +5338,13 @@ packages:
       graceful-fs: 4.2.10
       jest-diff: 29.4.0
       jest-get-type: 29.2.0
-      jest-haste-map: 29.4.0
+      jest-haste-map: 29.3.1
       jest-matcher-utils: 29.4.0
       jest-message-util: 29.4.0
       jest-util: 29.4.0
       natural-compare: 1.4.0
       pretty-format: 29.4.0
-      semver: 7.3.7
+      semver: 7.3.8
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5347,7 +5375,7 @@ packages:
       '@jest/types': 29.4.0
       '@types/node': 18.7.14
       chalk: 4.1.2
-      ci-info: 3.3.2
+      ci-info: 3.7.1
       graceful-fs: 4.2.10
       picomatch: 2.3.1
     dev: true
@@ -5359,13 +5387,13 @@ packages:
       '@jest/types': 29.4.0
       '@types/node': 18.7.14
       chalk: 4.1.2
-      ci-info: 3.3.2
+      ci-info: 3.7.1
       graceful-fs: 4.2.10
       picomatch: 2.3.1
     dev: true
 
-  /jest-validate/29.4.0:
-    resolution: {integrity: sha512-EXS7u594nX3aAPBnARxBdJ1eZ1cByV6MWrK0Qpt9lt/BcY0p0yYGp/EGJ8GhdLDQh+RFf8qMt2wzbbVzpj5+Vg==}
+  /jest-validate/29.3.1:
+    resolution: {integrity: sha512-N9Lr3oYR2Mpzuelp1F8negJR3YE+L1ebk1rYA5qYo9TTY3f9OWdptLoNSPP9itOCBIRBqjt/S5XHlzYglLN67g==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.4.0
@@ -5376,7 +5404,7 @@ packages:
       pretty-format: 29.4.0
     dev: true
 
-  /jest-watch-typeahead/2.2.1_jest@29.4.0:
+  /jest-watch-typeahead/2.2.1_jest@29.3.1:
     resolution: {integrity: sha512-jYpYmUnTzysmVnwq49TAxlmtOAwp8QIqvZyoofQFn8fiWhEDZj33ZXzg3JA4nGnzWFm1hbWf3ADpteUokvXgFA==}
     engines: {node: ^14.17.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -5384,7 +5412,7 @@ packages:
     dependencies:
       ansi-escapes: 6.0.0
       chalk: 4.1.2
-      jest: 29.4.0_4f2ldd7um3b3u4eyvetyqsphze
+      jest: 29.3.1_4f2ldd7um3b3u4eyvetyqsphze
       jest-regex-util: 29.2.0
       jest-watcher: 29.3.1
       slash: 5.0.0
@@ -5397,26 +5425,12 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/test-result': 29.3.1
-      '@jest/types': 29.3.1
-      '@types/node': 18.7.14
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      emittery: 0.13.1
-      jest-util: 29.3.1
-      string-length: 4.0.2
-    dev: true
-
-  /jest-watcher/29.4.0:
-    resolution: {integrity: sha512-PnnfLygNKelWOJwpAYlcsQjB+OxRRdckD0qiGmYng4Hkz1ZwK3jvCaJJYiywz2msQn4rBNLdriasJtv7YpWHpA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@jest/test-result': 29.4.0
       '@jest/types': 29.4.0
       '@types/node': 18.7.14
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
-      jest-util: 29.4.0
+      jest-util: 29.3.1
       string-length: 4.0.2
     dev: true
 
@@ -5429,8 +5443,8 @@ packages:
       supports-color: 8.1.1
     dev: false
 
-  /jest-worker/29.4.0:
-    resolution: {integrity: sha512-dICMQ+Q4W0QVMsaQzWlA1FVQhKNz7QcDCOGtbk1GCAd0Lai+wdkQvfmQwL4MjGumineh1xz+6M5oMj3rfWS02A==}
+  /jest-worker/29.3.1:
+    resolution: {integrity: sha512-lY4AnnmsEWeiXirAIA0c9SDPbuCBq8IYuDVL8PMm0MZ2PEs2yPvRA/J64QBXuZp7CYKrDM/rmNrc9/i3KJQncw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@types/node': 18.7.14
@@ -5439,8 +5453,8 @@ packages:
       supports-color: 8.1.1
     dev: true
 
-  /jest/29.4.0_4f2ldd7um3b3u4eyvetyqsphze:
-    resolution: {integrity: sha512-Zfd4UzNxPkSoHRBkg225rBjQNa6pVqbh20MGniAzwaOzYLd+pQUcAwH+WPxSXxKFs+QWYfPYIq9hIVSmdVQmPA==}
+  /jest/29.3.1_4f2ldd7um3b3u4eyvetyqsphze:
+    resolution: {integrity: sha512-6iWfL5DTT0Np6UYs/y5Niu7WIfNv/wRTtN5RSXt2DIEft3dx3zPuw/3WJQBCJfmEzvDiEKwoqMbGD9n49+qLSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
     peerDependencies:
@@ -5449,10 +5463,10 @@ packages:
       node-notifier:
         optional: true
     dependencies:
-      '@jest/core': 29.4.0_ts-node@10.9.1
+      '@jest/core': 29.3.1_ts-node@10.9.1
       '@jest/types': 29.4.0
       import-local: 3.1.0
-      jest-cli: 29.4.0_4f2ldd7um3b3u4eyvetyqsphze
+      jest-cli: 29.3.1_4f2ldd7um3b3u4eyvetyqsphze
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
@@ -5707,8 +5721,8 @@ packages:
     dependencies:
       yallist: 4.0.0
 
-  /lru-cache/7.14.0:
-    resolution: {integrity: sha512-EIRtP1GrSJny0dqb50QXRUNBxHJhcpxHC++M5tD7RYbvLLn5KVWKsbyswSSqDuU15UFi3bgTQIY8nhDMeF6aDQ==}
+  /lru-cache/7.14.1:
+    resolution: {integrity: sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==}
     engines: {node: '>=12'}
     dev: true
 
@@ -5750,7 +5764,7 @@ packages:
   /match-sorter/6.3.1:
     resolution: {integrity: sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==}
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.20.13
       remove-accents: 0.4.2
     dev: false
 
@@ -5937,7 +5951,7 @@ packages:
       decamelize: 1.2.0
       loud-rejection: 1.6.0
       map-obj: 1.0.1
-      minimist: 1.2.6
+      minimist: 1.2.7
       normalize-package-data: 2.5.0
       object-assign: 4.1.1
       read-pkg-up: 1.0.1
@@ -5951,7 +5965,7 @@ packages:
     dependencies:
       '@types/minimist': 1.2.2
       camelcase-keys: 6.2.2
-      decamelize-keys: 1.1.0
+      decamelize-keys: 1.1.1
       hard-rejection: 2.1.0
       minimist-options: 4.1.0
       normalize-package-data: 2.5.0
@@ -5969,7 +5983,7 @@ packages:
       '@types/minimist': 1.2.2
       camelcase-keys: 6.2.2
       decamelize: 1.2.0
-      decamelize-keys: 1.1.0
+      decamelize-keys: 1.1.1
       hard-rejection: 2.1.0
       minimist-options: 4.1.0
       normalize-package-data: 3.0.3
@@ -6383,6 +6397,10 @@ packages:
     resolution: {integrity: sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==}
     dev: true
 
+  /minimist/1.2.7:
+    resolution: {integrity: sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==}
+    dev: true
+
   /mixme/0.5.4:
     resolution: {integrity: sha512-3KYa4m4Vlqx98GPdOHghxSdNtTvcP8E0kkaJ5Dlh+h2DRzF7zpuVVcA8B0QpKd11YJeP9QQ7ASkKzOeu195Wzw==}
     engines: {node: '>= 8.0.0'}
@@ -6607,6 +6625,18 @@ packages:
       whatwg-url: 5.0.0
     dev: true
 
+  /node-fetch/2.6.8:
+    resolution: {integrity: sha512-RZ6dBYuj8dRSfxpUSu+NsdF1dpPpluJxwOp+6IoDp/sH2QNDSvurYsAa+F1WxY2RjA1iP93xhcsUoYbF2XBqVg==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
+    dev: true
+
   /node-int64/0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
@@ -6642,8 +6672,8 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       hosted-git-info: 4.1.0
-      is-core-module: 2.10.0
-      semver: 7.3.7
+      is-core-module: 2.11.0
+      semver: 7.3.8
       validate-npm-package-license: 3.0.4
     dev: true
 
@@ -6651,9 +6681,9 @@ packages:
     resolution: {integrity: sha512-EBk5QKKuocMJhB3BILuKhmaPjI8vNRSpIfO9woLC6NyHVkKKdVEdAO1mrT0ZfxNR1lKwCcTkuZfmGIFdizZ8Pg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     dependencies:
-      hosted-git-info: 5.1.0
-      is-core-module: 2.10.0
-      semver: 7.3.7
+      hosted-git-info: 5.2.1
+      is-core-module: 2.11.0
+      semver: 7.3.8
       validate-npm-package-license: 3.0.4
     dev: true
 
@@ -6695,8 +6725,8 @@ packages:
     engines: {node: '>= 6'}
     dev: true
 
-  /object-inspect/1.12.2:
-    resolution: {integrity: sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==}
+  /object-inspect/1.12.3:
+    resolution: {integrity: sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==}
     dev: true
 
   /object-keys/1.1.1:
@@ -7080,15 +7110,6 @@ packages:
       react-is: 18.2.0
     dev: true
 
-  /pretty-format/29.2.1:
-    resolution: {integrity: sha512-Y41Sa4aLCtKAXvwuIpTvcFBkyeYp2gdFWzXGA+ZNES3VwURIB165XO/z7CjETwzCCS53MjW/rLMyyqEnTtaOfA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@jest/schemas': 29.0.0
-      ansi-styles: 5.2.0
-      react-is: 18.2.0
-    dev: true
-
   /pretty-format/29.4.0:
     resolution: {integrity: sha512-J+EVUPXIBHCdWAbvGBwXs0mk3ljGppoh/076g1S8qYS8nVG4u/yrhMvyTFHYYYKWnDdgRLExx0vA7pzxVGdlNw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -7190,7 +7211,7 @@ packages:
     dependencies:
       deep-extend: 0.6.0
       ini: 1.3.8
-      minimist: 1.2.6
+      minimist: 1.2.7
       strip-json-comments: 2.0.1
     dev: true
 
@@ -7415,8 +7436,8 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
-  /resolve.exports/2.0.0:
-    resolution: {integrity: sha512-6K/gDlqgQscOlg9fSRpWstA8sYe8rbELsSTNpx+3kTrsVCzvSl0zIvRErM7fdl9ERWDsKnrLnwB+Ne89918XOg==}
+  /resolve.exports/1.1.1:
+    resolution: {integrity: sha512-/NtpHNDN7jWhAaQ9BvBUYZ6YTXsRBgfqWFWP7BZBaoMJO/I3G5OFzvTuWNlZC3aPjins1F+TNrLKsGbH4rfsRQ==}
     engines: {node: '>=10'}
     dev: true
 
@@ -7424,7 +7445,7 @@ packages:
     resolution: {integrity: sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==}
     hasBin: true
     dependencies:
-      is-core-module: 2.10.0
+      is-core-module: 2.11.0
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
     dev: true
@@ -7466,8 +7487,13 @@ packages:
       mri: 1.2.0
     dev: false
 
-  /safe-buffer/5.1.2:
-    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+  /safe-regex-test/1.0.0:
+    resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
+    dependencies:
+      call-bind: 1.0.2
+      get-intrinsic: 1.2.0
+      is-regex: 1.1.4
+    dev: true
 
   /safer-buffer/2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -7514,6 +7540,14 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
+    dev: true
+
+  /semver/7.3.8:
+    resolution: {integrity: sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
 
   /set-blocking/2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
@@ -7553,8 +7587,8 @@ packages:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.1.2
-      object-inspect: 1.12.2
+      get-intrinsic: 1.2.0
+      object-inspect: 1.12.3
     dev: true
 
   /signal-exit/3.0.7:
@@ -7588,7 +7622,7 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
     dependencies:
-      array.prototype.flat: 1.3.0
+      array.prototype.flat: 1.3.1
       breakword: 1.0.5
       grapheme-splitter: 1.0.4
       strip-ansi: 6.0.1
@@ -7654,7 +7688,7 @@ packages:
     resolution: {integrity: sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==}
     dependencies:
       spdx-expression-parse: 3.0.1
-      spdx-license-ids: 3.0.11
+      spdx-license-ids: 3.0.12
     dev: true
 
   /spdx-exceptions/2.3.0:
@@ -7665,11 +7699,11 @@ packages:
     resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
     dependencies:
       spdx-exceptions: 2.3.0
-      spdx-license-ids: 3.0.11
+      spdx-license-ids: 3.0.12
     dev: true
 
-  /spdx-license-ids/3.0.11:
-    resolution: {integrity: sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==}
+  /spdx-license-ids/3.0.12:
+    resolution: {integrity: sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==}
     dev: true
 
   /sprintf-js/1.0.3:
@@ -7717,20 +7751,20 @@ packages:
       strip-ansi: 6.0.1
     dev: true
 
-  /string.prototype.trimend/1.0.5:
-    resolution: {integrity: sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==}
+  /string.prototype.trimend/1.0.6:
+    resolution: {integrity: sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==}
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
-      es-abstract: 1.20.1
+      es-abstract: 1.21.1
     dev: true
 
-  /string.prototype.trimstart/1.0.5:
-    resolution: {integrity: sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==}
+  /string.prototype.trimstart/1.0.6:
+    resolution: {integrity: sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==}
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
-      es-abstract: 1.20.1
+      es-abstract: 1.21.1
     dev: true
 
   /stringify-entities/4.0.3:
@@ -8096,7 +8130,7 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /ts-jest/29.0.5_4rbbsuegxgizcahsqjbulrgqyq:
+  /ts-jest/29.0.5_f6moou735nhgqh2og2bhnoem4a:
     resolution: {integrity: sha512-PL3UciSgIpQ7f6XjVOmbi96vmDHUqAyqDr8YxzopDqX3kfgYtX1cuNeBjP+L9sFXi6nzsGGA6R3fP3DDDJyrxA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -8121,7 +8155,7 @@ packages:
       bs-logger: 0.2.6
       esbuild: 0.17.4
       fast-json-stable-stringify: 2.1.0
-      jest: 29.4.0_4f2ldd7um3b3u4eyvetyqsphze
+      jest: 29.3.1_4f2ldd7um3b3u4eyvetyqsphze
       jest-util: 29.3.1
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -8258,7 +8292,7 @@ packages:
       smartwrap: 2.0.2
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
-      yargs: 17.5.1
+      yargs: 17.6.2
     dev: true
 
   /turbo-darwin-64/1.7.0:
@@ -8359,6 +8393,14 @@ packages:
   /type-fest/3.1.0:
     resolution: {integrity: sha512-StmrZmK3eD9mDF9Vt7UhqthrDSk66O9iYl5t5a0TSoVkHjl0XZx/xuc/BRz4urAXXGHOY5OLsE0RdJFIApSFmw==}
     engines: {node: '>=14.16'}
+    dev: true
+
+  /typed-array-length/1.0.4:
+    resolution: {integrity: sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==}
+    dependencies:
+      call-bind: 1.0.2
+      for-each: 0.3.3
+      is-typed-array: 1.1.10
     dev: true
 
   /typedarray-to-buffer/3.1.5:
@@ -8534,7 +8576,7 @@ packages:
       is-yarn-global: 0.3.0
       latest-version: 5.1.0
       pupa: 2.1.1
-      semver: 7.3.7
+      semver: 7.3.8
       semver-diff: 3.1.1
       xdg-basedir: 4.0.0
     dev: true
@@ -8579,9 +8621,9 @@ packages:
     resolution: {integrity: sha512-74Y4LqY74kLE6IFyIjPtkSTWzUZmj8tdHT9Ii/26dvQ6K9Dl2NbEfj0XgU2sHCtKgt5VupqhlO/5aWuqS+IY1w==}
     engines: {node: '>=10.12.0'}
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.15
+      '@jridgewell/trace-mapping': 0.3.17
       '@types/istanbul-lib-coverage': 2.0.4
-      convert-source-map: 1.8.0
+      convert-source-map: 1.9.0
     dev: true
 
   /validate-npm-package-license/3.0.4:
@@ -8630,7 +8672,7 @@ packages:
   /wcwidth/1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
     dependencies:
-      defaults: 1.0.3
+      defaults: 1.0.4
     dev: true
 
   /web-streams-polyfill/4.0.0-beta.3:
@@ -8706,6 +8748,18 @@ packages:
       path-exists: 4.0.0
     dev: true
 
+  /which-typed-array/1.1.9:
+    resolution: {integrity: sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      available-typed-arrays: 1.0.5
+      call-bind: 1.0.2
+      for-each: 0.3.3
+      gopd: 1.0.1
+      has-tostringtag: 1.0.0
+      is-typed-array: 1.1.10
+    dev: true
+
   /which/1.3.1:
     resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
     hasBin: true
@@ -8757,21 +8811,12 @@ packages:
       typedarray-to-buffer: 3.1.5
     dev: true
 
-  /write-file-atomic/4.0.1:
-    resolution: {integrity: sha512-nSKUxgAbyioruk6hU87QzVbY279oYT6uiwgDoujth2ju4mJ+TZau7SQBhtbTmUyuNYTuXnSyRn66FV0+eCgcrQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16}
+  /write-file-atomic/4.0.2:
+    resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     dependencies:
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
-    dev: false
-
-  /write-file-atomic/5.0.0:
-    resolution: {integrity: sha512-R7NYMnHSlV42K54lwY9lvW6MnSm1HSJqZL3xiSgi9E7//FYaI74r2G0rd+/X6VAMkHEdzxQaU5HUOXWUz5kA/w==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-    dependencies:
-      imurmurhash: 0.1.4
-      signal-exit: 3.0.7
-    dev: true
 
   /write-json-file/4.3.0:
     resolution: {integrity: sha512-PxiShnxf0IlnQuMYOPPhPkhExoCQuTUNPOa/2JWCYTmBquU9njyyDuwRKN26IZBlp4yn1nt+Agh2HOOBl+55HQ==}
@@ -8863,11 +8908,11 @@ packages:
       yargs-parser: 20.2.9
     dev: true
 
-  /yargs/17.5.1:
-    resolution: {integrity: sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==}
+  /yargs/17.6.2:
+    resolution: {integrity: sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==}
     engines: {node: '>=12'}
     dependencies:
-      cliui: 7.0.4
+      cliui: 8.0.1
       escalade: 3.1.1
       get-caller-file: 2.0.5
       require-directory: 2.1.1

--- a/turbo.json
+++ b/turbo.json
@@ -3,11 +3,11 @@
   "globalEnv": ["RUNNER_OS", "NODE_VERSION"],
   "pipeline": {
     "build": {
-      "cache": false,
       "outputs": ["dist/**"],
       "dependsOn": ["^build"]
     },
     "edge-runtime#build": {
+      "cache": false,
       "dependsOn": ["^build"],
       "outputs": ["src/version.ts"]
     },


### PR DESCRIPTION
### 📖 What's in there?

Current node-utils have a fixed origin for mapped web requests. A better solution is to leverage the incomingMessage's `host` header, and only default to a fixed value in case the header is missing.

This PR also brings a mocked `fetchEvent` (web handler second parameter). It will throw when using `waitUntil()`,  so our users would know this feature is not implemented yet.

- feat(node-utils): uses incoming host header to determine request's origin
- feat(node-utils): provides mocked fetch event which throws on waitUntil
- fix(ci): reverts jest version bump from dependabot which broke [main](https://github.com/vercel/edge-runtime/commit/64ae0773760aa1eab6ceaa15090f56f616ca9dec)

### 📓 Notes to reviewers

It is likely that no one is using this package. Yet, these are 2 breaking changes, since the required options and dependencies have changed.

Please [hide whitespace changes](https://github.com/vercel/edge-runtime/pull/244/files?diff=split&w=1) when reviewing, to find the actual changes.