### PR TITLE
actually return context object in example

### DIFF
--- a/docs/pages/packages/vm.mdx
+++ b/docs/pages/packages/vm.mdx
@@ -88,7 +88,7 @@ Allows to extend the VMContext.
 ```js
 const vm = new EdgeVM({
   extend: (context) =>
-    Object.assign(context, {
+    return Object.assign(context, {
       process: { env: { NODE_ENV: 'development' } },
     }),
 })


### PR DESCRIPTION
The following sentence explicitly states that this is necessary.

Best,
Michel