### PR TITLE
fix(cookies): be able to split `set-cookie` without `getAll`

### DIFF
--- a/.changeset/heavy-rabbits-glow.md
+++ b/.changeset/heavy-rabbits-glow.md
@@ -1,0 +1,7 @@
+---
+'@edge-runtime/cookies': patch
+---
+
+Be able to split `set-cookie` without `getAll`
+
+Ref: https://github.com/whatwg/fetch/issues/973

--- a/packages/cookies/src/response-cookies.ts
+++ b/packages/cookies/src/response-cookies.ts
@@ -14,14 +14,20 @@ export class ResponseCookies {
 
   constructor(responseHeaders: Headers) {
     this._headers = responseHeaders
-    // @ts-expect-error See https://github.com/whatwg/fetch/issues/973
-    const headers = this._headers.getAll('set-cookie')
 
-    for (const header of headers) {
-      const parsed = parseSetCookieString(header)
-      if (parsed) {
-        this._parsed.set(parsed.name, parsed)
-      }
+    const setCookie =
+      // @ts-expect-error See https://github.com/whatwg/fetch/issues/973
+      responseHeaders.getAll?.('set-cookie') ??
+      responseHeaders.get('set-cookie') ??
+      []
+
+    const cookieStrings = Array.isArray(setCookie)
+      ? setCookie
+      : splitCookiesString(setCookie)
+
+    for (const cookieString of cookieStrings) {
+      const parsed = parseSetCookieString(cookieString)
+      if (parsed) this._parsed.set(parsed.name, parsed)
     }
   }
 
@@ -101,4 +107,83 @@ function normalizeCookie(cookie: ResponseCookie = { name: '', value: '' }) {
   }
 
   return cookie
+}
+
+/**
+ * @source https://github.com/nfriedly/set-cookie-parser/blob/master/lib/set-cookie.js
+ *
+ * Set-Cookie header field-values are sometimes comma joined in one string. This splits them without choking on commas
+ * that are within a single set-cookie field-value, such as in the Expires portion.
+ * This is uncommon, but explicitly allowed - see https://tools.ietf.org/html/rfc2616#section-4.2
+ * Node.js does this for every header *except* set-cookie - see https://github.com/nodejs/node/blob/d5e363b77ebaf1caf67cd7528224b651c86815c1/lib/_http_incoming.js#L128
+ * React Native's fetch does this for *every* header, including set-cookie.
+ *
+ * Based on: https://github.com/google/j2objc/commit/16820fdbc8f76ca0c33472810ce0cb03d20efe25
+ * Credits to: https://github.com/tomball for original and https://github.com/chrusart for JavaScript implementation
+ */
+function splitCookiesString(cookiesString: string) {
+  if (!cookiesString) return []
+  var cookiesStrings = []
+  var pos = 0
+  var start
+  var ch
+  var lastComma
+  var nextStart
+  var cookiesSeparatorFound
+
+  function skipWhitespace() {
+    while (pos < cookiesString.length && /\s/.test(cookiesString.charAt(pos))) {
+      pos += 1
+    }
+    return pos < cookiesString.length
+  }
+
+  function notSpecialChar() {
+    ch = cookiesString.charAt(pos)
+
+    return ch !== '=' && ch !== ';' && ch !== ','
+  }
+
+  while (pos < cookiesString.length) {
+    start = pos
+    cookiesSeparatorFound = false
+
+    while (skipWhitespace()) {
+      ch = cookiesString.charAt(pos)
+      if (ch === ',') {
+        // ',' is a cookie separator if we have later first '=', not ';' or ','
+        lastComma = pos
+        pos += 1
+
+        skipWhitespace()
+        nextStart = pos
+
+        while (pos < cookiesString.length && notSpecialChar()) {
+          pos += 1
+        }
+
+        // currently special character
+        if (pos < cookiesString.length && cookiesString.charAt(pos) === '=') {
+          // we found cookies separator
+          cookiesSeparatorFound = true
+          // pos is inside the next cookie, so back up and return it.
+          pos = nextStart
+          cookiesStrings.push(cookiesString.substring(start, lastComma))
+          start = pos
+        } else {
+          // in param ',' or param separator ';',
+          // we continue from that comma
+          pos = lastComma + 1
+        }
+      } else {
+        pos += 1
+      }
+    }
+
+    if (!cookiesSeparatorFound || pos >= cookiesString.length) {
+      cookiesStrings.push(cookiesString.substring(start, cookiesString.length))
+    }
+  }
+
+  return cookiesStrings
 }

--- a/packages/cookies/src/serialize.ts
+++ b/packages/cookies/src/serialize.ts
@@ -15,7 +15,7 @@ export function serialize(c: ResponseCookie | RequestCookie): string {
 }
 
 /**
- * Parse a `Cookie` or `Set-Cookie header value
+ * Parse a `Cookie` or `Set-Cookie` header value
  */
 export function parseCookieString(cookie: string): Map<string, string> {
   const map = new Map<string, string>()

--- a/packages/cookies/test/response-cookies.test.ts
+++ b/packages/cookies/test/response-cookies.test.ts
@@ -125,3 +125,18 @@ test('formatting with @edge-runtime/format', () => {
     `"ResponseCookies {"a":{"name":"a","value":"1","httpOnly":true,"path":"/"},"b":{"name":"b","value":"2","sameSite":"lax","path":"/"}}"`
   )
 })
+
+test('splitting multiple set-cookie', () => {
+  const headers = new Headers()
+  headers.set('set-cookie', 'foo=bar')
+  headers.append('set-cookie', 'fooz=barz')
+  const cookies = new ResponseCookies(headers)
+  expect(cookies.get('foo')?.value).toBe('bar')
+  expect(cookies.get('fooz')?.value).toBe('barz')
+
+  const headers2 = new Headers({ 'set-cookie': 'foo=bar' })
+  headers2.set('set-cookie', 'fooz=barz') // override on purpose
+  const cookies2 = new ResponseCookies(headers2)
+  expect(cookies2.get('foo')?.value).toBe(undefined)
+  expect(cookies2.get('fooz')?.value).toBe('barz')
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,22 +25,22 @@ importers:
     devDependencies:
       '@changesets/cli': 2.26.0
       '@jest/types': 29.1.2
-      '@svitejs/changesets-changelog-github-compact': 0.1.1
+      '@svitejs/changesets-changelog-github-compact': 1.1.0
       '@types/jest': 29.0.3
       '@types/node': 14.18.32
       c8: 7.12.0
       esbuild: 0.17.5
       finepack: 2.10.15
-      git-authors-cli: 1.0.44
+      git-authors-cli: 1.0.45
       jest: 29.3.1_4f2ldd7um3b3u4eyvetyqsphze
       jest-watch-typeahead: 2.2.1_jest@29.3.1
       nano-staged: 0.8.0
       prettier: 2.8.3
-      simple-git-hooks: 2.8.0
-      ts-jest: 29.0.5_6qbjmobtf6dep6xdreexz7rbsq
-      ts-node: 10.9.1_gvautt7gdeuivcibnat6klxaoe
-      turbo: 1.6.3
-      typescript: 4.9.5
+      simple-git-hooks: 2.8.1
+      ts-jest: 29.0.5_v3grav4h7mcqipyefxtzcgjwb4
+      ts-node: 10.9.1_6yr256pmli274zrjafonbeyefq
+      turbo: 1.7.0
+      typescript: 4.9.4
 
   docs:
     specifiers:
@@ -661,8 +661,8 @@ packages:
       semver: 5.7.1
     dev: true
 
-  /@changesets/get-github-info/0.5.1:
-    resolution: {integrity: sha512-w2yl3AuG+hFuEEmT6j1zDlg7GQLM/J2UxTmk0uJBMdRqHni4zXGe/vUlPfLom5KfX3cRfHc0hzGvloDPjWFNZw==}
+  /@changesets/get-github-info/0.5.2:
+    resolution: {integrity: sha512-JppheLu7S114aEs157fOZDjFqUDpm7eHdq5E8SSR0gUBTEK0cNSHsrSR5a66xs0z3RWuo46QvA3vawp8BxDHvg==}
     dependencies:
       dataloader: 1.4.0
       node-fetch: 2.6.8
@@ -1884,11 +1884,11 @@ packages:
     dependencies:
       '@sinonjs/commons': 1.8.3
 
-  /@svitejs/changesets-changelog-github-compact/0.1.1:
-    resolution: {integrity: sha512-eBi211CfmKtkxB6tINicaDPBMbolswPbaAy7kCx+uUFL/LxztLm9cB+7jP54TgCrv+mMz8vSJWIs/baH63PjsA==}
-    engines: {node: ^12.20 || ^14.13.1 || >= 16}
+  /@svitejs/changesets-changelog-github-compact/1.1.0:
+    resolution: {integrity: sha512-qhUGGDHcpbY2zpjW3SwqchuW8J/5EzlPFud7xNntHKA7f3a/mx5+g+ruJKFHSAiVZYo30PALt+AyhmPUNKH/Og==}
+    engines: {node: ^14.13.1 || ^16.0.0 || >=18}
     dependencies:
-      '@changesets/get-github-info': 0.5.1
+      '@changesets/get-github-info': 0.5.2
       dotenv: 16.0.3
     transitivePeerDependencies:
       - encoding
@@ -4159,8 +4159,8 @@ packages:
       get-intrinsic: 1.2.0
     dev: true
 
-  /git-authors-cli/1.0.44:
-    resolution: {integrity: sha512-OD1mYIfWqxmL20IocGihWLYHNe5VsFWQT0SFGKZQM4/msXcnHQ9EX8qUeCc4WYNu/f50VMeMVxaOTwCohMKJhA==}
+  /git-authors-cli/1.0.45:
+    resolution: {integrity: sha512-qrTmTCRs0pBmxfHK2RAy3sxyLV6fXwR/7A5oKeidue7EVBX2UKKFbU7/ZmM94A5pTE4hV+myApt71RF2RZZZIA==}
     engines: {node: '>= 8'}
     hasBin: true
     dependencies:
@@ -4930,7 +4930,7 @@ packages:
       pretty-format: 29.4.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1_gvautt7gdeuivcibnat6klxaoe
+      ts-node: 10.9.1_6yr256pmli274zrjafonbeyefq
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4970,7 +4970,7 @@ packages:
       pretty-format: 29.4.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1_gvautt7gdeuivcibnat6klxaoe
+      ts-node: 10.9.1_6yr256pmli274zrjafonbeyefq
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7583,8 +7583,8 @@ packages:
   /signal-exit/3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
-  /simple-git-hooks/2.8.0:
-    resolution: {integrity: sha512-ocmZQORwa6x9mxg+gVIAp5o4wXiWOHGXyrDBA0+UxGKIEKOyFtL4LWNKkP/2ornQPdlnlDGDteVeYP5FjhIoWA==}
+  /simple-git-hooks/2.8.1:
+    resolution: {integrity: sha512-DYpcVR1AGtSfFUNzlBdHrQGPsOhuuEJ/FkmPOOlFysP60AHd3nsEpkGq/QEOdtUyT1Qhk7w9oLmFoMG+75BDog==}
     hasBin: true
     requiresBuild: true
     dev: true
@@ -8119,7 +8119,7 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /ts-jest/29.0.5_6qbjmobtf6dep6xdreexz7rbsq:
+  /ts-jest/29.0.5_v3grav4h7mcqipyefxtzcgjwb4:
     resolution: {integrity: sha512-PL3UciSgIpQ7f6XjVOmbi96vmDHUqAyqDr8YxzopDqX3kfgYtX1cuNeBjP+L9sFXi6nzsGGA6R3fP3DDDJyrxA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -8150,7 +8150,7 @@ packages:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.3.7
-      typescript: 4.9.5
+      typescript: 4.9.4
       yargs-parser: 21.1.1
     dev: true
 
@@ -8161,7 +8161,7 @@ packages:
       code-block-writer: 11.0.3
     dev: false
 
-  /ts-node/10.9.1_gvautt7gdeuivcibnat6klxaoe:
+  /ts-node/10.9.1_6yr256pmli274zrjafonbeyefq:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -8187,7 +8187,7 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 4.9.5
+      typescript: 4.9.4
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: true
@@ -8284,65 +8284,65 @@ packages:
       yargs: 17.6.2
     dev: true
 
-  /turbo-darwin-64/1.6.3:
-    resolution: {integrity: sha512-QmDIX0Yh1wYQl0bUS0gGWwNxpJwrzZU2GIAYt3aOKoirWA2ecnyb3R6ludcS1znfNV2MfunP+l8E3ncxUHwtjA==}
+  /turbo-darwin-64/1.7.0:
+    resolution: {integrity: sha512-hSGAueSf5Ko8J67mpqjpt9FsP6ePn1nMcl7IVPoJq5dHsgX3anCP/BPlexJ502bNK+87DDyhQhJ/LPSJXKrSYQ==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-darwin-arm64/1.6.3:
-    resolution: {integrity: sha512-75DXhFpwE7CinBbtxTxH08EcWrxYSPFow3NaeFwsG8aymkWXF+U2aukYHJA6I12n9/dGqf7yRXzkF0S/9UtdyQ==}
+  /turbo-darwin-arm64/1.7.0:
+    resolution: {integrity: sha512-BLLOW5W6VZxk5+0ZOj5AO1qjM0P5isIgjbEuyAl8lHZ4s9antUbY4CtFrspT32XxPTYoDl4UjviPMcSsbcl3WQ==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-64/1.6.3:
-    resolution: {integrity: sha512-O9uc6J0yoRPWdPg9THRQi69K6E2iZ98cRHNvus05lZbcPzZTxJYkYGb5iagCmCW/pq6fL4T4oLWAd6evg2LGQA==}
+  /turbo-linux-64/1.7.0:
+    resolution: {integrity: sha512-aw2qxmfZa+kT87SB3GNUoFimqEPzTlzlRqhPgHuAAT6Uf0JHnmebPt4K+ZPtDNl5yfVmtB05bhHPqw+5QV97Yg==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-arm64/1.6.3:
-    resolution: {integrity: sha512-dCy667qqEtZIhulsRTe8hhWQNCJO0i20uHXv7KjLHuFZGCeMbWxB8rsneRoY+blf8+QNqGuXQJxak7ayjHLxiA==}
+  /turbo-linux-arm64/1.7.0:
+    resolution: {integrity: sha512-AJEx2jX+zO5fQtJpO3r6uhTabj4oSA5ZhB7zTs/rwu/XqoydsvStA4X8NDW4poTbOjF7DcSHizqwi04tSMzpJw==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-64/1.6.3:
-    resolution: {integrity: sha512-lKRqwL3mrVF09b9KySSaOwetehmGknV9EcQTF7d2dxngGYYX1WXoQLjFP9YYH8ZV07oPm+RUOAKSCQuDuMNhiA==}
+  /turbo-windows-64/1.7.0:
+    resolution: {integrity: sha512-ewj7PPv2uxqv0r31hgnBa3E5qwUu7eyVRP5M1gB/TJXfSHduU79gbxpKCyxIZv2fL/N2/3U7EPOQPSZxBAoljA==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-arm64/1.6.3:
-    resolution: {integrity: sha512-BXY1sDPEA1DgPwuENvDCD8B7Hb0toscjus941WpL8CVd10hg9pk/MWn9CNgwDO5Q9ks0mw+liDv2EMnleEjeNA==}
+  /turbo-windows-arm64/1.7.0:
+    resolution: {integrity: sha512-LzjOUzveWkvTD0jP8DBMYiAnYemmydsvqxdSmsUapHHJkl6wKZIOQNSO7pxsy+9XM/1/+0f9Y9F9ZNl5lePTEA==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo/1.6.3:
-    resolution: {integrity: sha512-FtfhJLmEEtHveGxW4Ye/QuY85AnZ2ZNVgkTBswoap7UMHB1+oI4diHPNyqrQLG4K1UFtCkjOlVoLsllUh/9QRw==}
+  /turbo/1.7.0:
+    resolution: {integrity: sha512-cwympNwQNnQZ/TffBd8yT0i0O10Cf/hlxccCYgUcwhcGEb9rDjE5thDbHoHw1hlJQUF/5ua7ERJe7Zr0lNE/ww==}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      turbo-darwin-64: 1.6.3
-      turbo-darwin-arm64: 1.6.3
-      turbo-linux-64: 1.6.3
-      turbo-linux-arm64: 1.6.3
-      turbo-windows-64: 1.6.3
-      turbo-windows-arm64: 1.6.3
+      turbo-darwin-64: 1.7.0
+      turbo-darwin-arm64: 1.7.0
+      turbo-linux-64: 1.7.0
+      turbo-linux-arm64: 1.7.0
+      turbo-windows-64: 1.7.0
+      turbo-windows-arm64: 1.7.0
     dev: true
 
   /type-detect/4.0.8:
@@ -8398,8 +8398,8 @@ packages:
       is-typedarray: 1.0.0
     dev: true
 
-  /typescript/4.9.5:
-    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
+  /typescript/4.9.4:
+    resolution: {integrity: sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,22 +25,22 @@ importers:
     devDependencies:
       '@changesets/cli': 2.26.0
       '@jest/types': 29.1.2
-      '@svitejs/changesets-changelog-github-compact': 1.1.0
+      '@svitejs/changesets-changelog-github-compact': 0.1.1
       '@types/jest': 29.0.3
       '@types/node': 14.18.32
       c8: 7.12.0
       esbuild: 0.17.5
       finepack: 2.10.15
-      git-authors-cli: 1.0.45
+      git-authors-cli: 1.0.44
       jest: 29.3.1_4f2ldd7um3b3u4eyvetyqsphze
       jest-watch-typeahead: 2.2.1_jest@29.3.1
       nano-staged: 0.8.0
       prettier: 2.8.3
-      simple-git-hooks: 2.8.1
-      ts-jest: 29.0.5_v3grav4h7mcqipyefxtzcgjwb4
-      ts-node: 10.9.1_6yr256pmli274zrjafonbeyefq
-      turbo: 1.7.0
-      typescript: 4.9.4
+      simple-git-hooks: 2.8.0
+      ts-jest: 29.0.5_6qbjmobtf6dep6xdreexz7rbsq
+      ts-node: 10.9.1_gvautt7gdeuivcibnat6klxaoe
+      turbo: 1.6.3
+      typescript: 4.9.5
 
   docs:
     specifiers:
@@ -661,8 +661,8 @@ packages:
       semver: 5.7.1
     dev: true
 
-  /@changesets/get-github-info/0.5.2:
-    resolution: {integrity: sha512-JppheLu7S114aEs157fOZDjFqUDpm7eHdq5E8SSR0gUBTEK0cNSHsrSR5a66xs0z3RWuo46QvA3vawp8BxDHvg==}
+  /@changesets/get-github-info/0.5.1:
+    resolution: {integrity: sha512-w2yl3AuG+hFuEEmT6j1zDlg7GQLM/J2UxTmk0uJBMdRqHni4zXGe/vUlPfLom5KfX3cRfHc0hzGvloDPjWFNZw==}
     dependencies:
       dataloader: 1.4.0
       node-fetch: 2.6.8
@@ -1884,11 +1884,11 @@ packages:
     dependencies:
       '@sinonjs/commons': 1.8.3
 
-  /@svitejs/changesets-changelog-github-compact/1.1.0:
-    resolution: {integrity: sha512-qhUGGDHcpbY2zpjW3SwqchuW8J/5EzlPFud7xNntHKA7f3a/mx5+g+ruJKFHSAiVZYo30PALt+AyhmPUNKH/Og==}
-    engines: {node: ^14.13.1 || ^16.0.0 || >=18}
+  /@svitejs/changesets-changelog-github-compact/0.1.1:
+    resolution: {integrity: sha512-eBi211CfmKtkxB6tINicaDPBMbolswPbaAy7kCx+uUFL/LxztLm9cB+7jP54TgCrv+mMz8vSJWIs/baH63PjsA==}
+    engines: {node: ^12.20 || ^14.13.1 || >= 16}
     dependencies:
-      '@changesets/get-github-info': 0.5.2
+      '@changesets/get-github-info': 0.5.1
       dotenv: 16.0.3
     transitivePeerDependencies:
       - encoding
@@ -4159,8 +4159,8 @@ packages:
       get-intrinsic: 1.2.0
     dev: true
 
-  /git-authors-cli/1.0.45:
-    resolution: {integrity: sha512-qrTmTCRs0pBmxfHK2RAy3sxyLV6fXwR/7A5oKeidue7EVBX2UKKFbU7/ZmM94A5pTE4hV+myApt71RF2RZZZIA==}
+  /git-authors-cli/1.0.44:
+    resolution: {integrity: sha512-OD1mYIfWqxmL20IocGihWLYHNe5VsFWQT0SFGKZQM4/msXcnHQ9EX8qUeCc4WYNu/f50VMeMVxaOTwCohMKJhA==}
     engines: {node: '>= 8'}
     hasBin: true
     dependencies:
@@ -4930,7 +4930,7 @@ packages:
       pretty-format: 29.4.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1_6yr256pmli274zrjafonbeyefq
+      ts-node: 10.9.1_gvautt7gdeuivcibnat6klxaoe
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4970,7 +4970,7 @@ packages:
       pretty-format: 29.4.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1_6yr256pmli274zrjafonbeyefq
+      ts-node: 10.9.1_gvautt7gdeuivcibnat6klxaoe
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7583,8 +7583,8 @@ packages:
   /signal-exit/3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
-  /simple-git-hooks/2.8.1:
-    resolution: {integrity: sha512-DYpcVR1AGtSfFUNzlBdHrQGPsOhuuEJ/FkmPOOlFysP60AHd3nsEpkGq/QEOdtUyT1Qhk7w9oLmFoMG+75BDog==}
+  /simple-git-hooks/2.8.0:
+    resolution: {integrity: sha512-ocmZQORwa6x9mxg+gVIAp5o4wXiWOHGXyrDBA0+UxGKIEKOyFtL4LWNKkP/2ornQPdlnlDGDteVeYP5FjhIoWA==}
     hasBin: true
     requiresBuild: true
     dev: true
@@ -8119,7 +8119,7 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /ts-jest/29.0.5_v3grav4h7mcqipyefxtzcgjwb4:
+  /ts-jest/29.0.5_6qbjmobtf6dep6xdreexz7rbsq:
     resolution: {integrity: sha512-PL3UciSgIpQ7f6XjVOmbi96vmDHUqAyqDr8YxzopDqX3kfgYtX1cuNeBjP+L9sFXi6nzsGGA6R3fP3DDDJyrxA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -8150,7 +8150,7 @@ packages:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.3.7
-      typescript: 4.9.4
+      typescript: 4.9.5
       yargs-parser: 21.1.1
     dev: true
 
@@ -8161,7 +8161,7 @@ packages:
       code-block-writer: 11.0.3
     dev: false
 
-  /ts-node/10.9.1_6yr256pmli274zrjafonbeyefq:
+  /ts-node/10.9.1_gvautt7gdeuivcibnat6klxaoe:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -8187,7 +8187,7 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 4.9.4
+      typescript: 4.9.5
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: true
@@ -8284,65 +8284,65 @@ packages:
       yargs: 17.6.2
     dev: true
 
-  /turbo-darwin-64/1.7.0:
-    resolution: {integrity: sha512-hSGAueSf5Ko8J67mpqjpt9FsP6ePn1nMcl7IVPoJq5dHsgX3anCP/BPlexJ502bNK+87DDyhQhJ/LPSJXKrSYQ==}
+  /turbo-darwin-64/1.6.3:
+    resolution: {integrity: sha512-QmDIX0Yh1wYQl0bUS0gGWwNxpJwrzZU2GIAYt3aOKoirWA2ecnyb3R6ludcS1znfNV2MfunP+l8E3ncxUHwtjA==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-darwin-arm64/1.7.0:
-    resolution: {integrity: sha512-BLLOW5W6VZxk5+0ZOj5AO1qjM0P5isIgjbEuyAl8lHZ4s9antUbY4CtFrspT32XxPTYoDl4UjviPMcSsbcl3WQ==}
+  /turbo-darwin-arm64/1.6.3:
+    resolution: {integrity: sha512-75DXhFpwE7CinBbtxTxH08EcWrxYSPFow3NaeFwsG8aymkWXF+U2aukYHJA6I12n9/dGqf7yRXzkF0S/9UtdyQ==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-64/1.7.0:
-    resolution: {integrity: sha512-aw2qxmfZa+kT87SB3GNUoFimqEPzTlzlRqhPgHuAAT6Uf0JHnmebPt4K+ZPtDNl5yfVmtB05bhHPqw+5QV97Yg==}
+  /turbo-linux-64/1.6.3:
+    resolution: {integrity: sha512-O9uc6J0yoRPWdPg9THRQi69K6E2iZ98cRHNvus05lZbcPzZTxJYkYGb5iagCmCW/pq6fL4T4oLWAd6evg2LGQA==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-arm64/1.7.0:
-    resolution: {integrity: sha512-AJEx2jX+zO5fQtJpO3r6uhTabj4oSA5ZhB7zTs/rwu/XqoydsvStA4X8NDW4poTbOjF7DcSHizqwi04tSMzpJw==}
+  /turbo-linux-arm64/1.6.3:
+    resolution: {integrity: sha512-dCy667qqEtZIhulsRTe8hhWQNCJO0i20uHXv7KjLHuFZGCeMbWxB8rsneRoY+blf8+QNqGuXQJxak7ayjHLxiA==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-64/1.7.0:
-    resolution: {integrity: sha512-ewj7PPv2uxqv0r31hgnBa3E5qwUu7eyVRP5M1gB/TJXfSHduU79gbxpKCyxIZv2fL/N2/3U7EPOQPSZxBAoljA==}
+  /turbo-windows-64/1.6.3:
+    resolution: {integrity: sha512-lKRqwL3mrVF09b9KySSaOwetehmGknV9EcQTF7d2dxngGYYX1WXoQLjFP9YYH8ZV07oPm+RUOAKSCQuDuMNhiA==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-arm64/1.7.0:
-    resolution: {integrity: sha512-LzjOUzveWkvTD0jP8DBMYiAnYemmydsvqxdSmsUapHHJkl6wKZIOQNSO7pxsy+9XM/1/+0f9Y9F9ZNl5lePTEA==}
+  /turbo-windows-arm64/1.6.3:
+    resolution: {integrity: sha512-BXY1sDPEA1DgPwuENvDCD8B7Hb0toscjus941WpL8CVd10hg9pk/MWn9CNgwDO5Q9ks0mw+liDv2EMnleEjeNA==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo/1.7.0:
-    resolution: {integrity: sha512-cwympNwQNnQZ/TffBd8yT0i0O10Cf/hlxccCYgUcwhcGEb9rDjE5thDbHoHw1hlJQUF/5ua7ERJe7Zr0lNE/ww==}
+  /turbo/1.6.3:
+    resolution: {integrity: sha512-FtfhJLmEEtHveGxW4Ye/QuY85AnZ2ZNVgkTBswoap7UMHB1+oI4diHPNyqrQLG4K1UFtCkjOlVoLsllUh/9QRw==}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      turbo-darwin-64: 1.7.0
-      turbo-darwin-arm64: 1.7.0
-      turbo-linux-64: 1.7.0
-      turbo-linux-arm64: 1.7.0
-      turbo-windows-64: 1.7.0
-      turbo-windows-arm64: 1.7.0
+      turbo-darwin-64: 1.6.3
+      turbo-darwin-arm64: 1.6.3
+      turbo-linux-64: 1.6.3
+      turbo-linux-arm64: 1.6.3
+      turbo-windows-64: 1.6.3
+      turbo-windows-arm64: 1.6.3
     dev: true
 
   /type-detect/4.0.8:
@@ -8398,8 +8398,8 @@ packages:
       is-typedarray: 1.0.0
     dev: true
 
-  /typescript/4.9.4:
-    resolution: {integrity: sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==}
+  /typescript/4.9.5:
+    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true


### PR DESCRIPTION
Currently, if a user sets multiple cookies in a series, only the second cookie is set in the `set-cookie` header.

When this is merged, I will update https://github.com/vercel/next.js/tree/canary/packages/next/src/server/web/spec-extension/cookies to drop the code and use the pre-compiled version of this package again.

[Slack thread 1](https://vercel.slack.com/archives/C03S8ED1DKM/p1675694485304329), [Slack thread 2](https://vercel.slack.com/archives/C03ENM5HB4K/p1668173326539069)