### PR TITLE
fix(ts): mark `.getAll()` as optional

### DIFF
--- a/.changeset/twenty-dancers-swim.md
+++ b/.changeset/twenty-dancers-swim.md
@@ -1,0 +1,6 @@
+---
+'@edge-runtime/node-utils': patch
+'@edge-runtime/primitives': patch
+---
+
+We are already falling back in code, the types just need to reflect this correctly

--- a/packages/node-utils/src/edge-to-node/headers.ts
+++ b/packages/node-utils/src/edge-to-node/headers.ts
@@ -12,9 +12,7 @@ export function toOutgoingHeaders(
       outputHeaders[name] = value
       if (name.toLowerCase() === 'set-cookie') {
         outputHeaders[name] =
-          'getAll' in headers
-            ? headers.getAll('set-cookie')
-            : splitCookiesString(value)
+          headers.getAll?.('set-cookie') ?? splitCookiesString(value)
       }
     }
   }

--- a/packages/primitives/type-definitions/fetch.d.ts
+++ b/packages/primitives/type-definitions/fetch.d.ts
@@ -1,5 +1,5 @@
 export class Headers extends globalThis.Headers {
-  getAll(key: 'set-cookie'): string[]
+  getAll?(key: 'set-cookie'): string[]
 }
 
 export class Request extends globalThis.Request {


### PR DESCRIPTION
Follow-up on: #255

Blocking to upgrade `edge-runtime` packages in https://github.com/vercel/next.js/pull/42736