### PR TITLE
ci: skip docs build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,9 +44,9 @@ jobs:
 
       - run: pnpm install --recursive --loglevel=error
 
-      - run: pnpm build
+      - run: pnpm build --filter='!@edge-runtime/docs'
 
-      - run: pnpm test
+      - run: pnpm test --filter='!@edge-runtime/docs'
 
       - name: Generate coverage
         run: pnpm coverage


### PR DESCRIPTION
CI will always fail because `@edge-runtime/docs` is not compatible with Node.js v14. CI will exclude the `@edge-runtime/docs` build so that it will pass CI. The `@edge-runtime/docs` build should be secured by deploying to Vercel.