### PR TITLE
fix: use valid SPDX license expression

### DIFF
--- a/.changeset/unlucky-items-swim.md
+++ b/.changeset/unlucky-items-swim.md
@@ -1,0 +1,16 @@
+---
+"@edge-runtime/cookies": patch
+"@edge-runtime/feature-detector": patch
+"@edge-runtime/format": patch
+"@edge-runtime/jest-environment": patch
+"@edge-runtime/jest-expect": patch
+"@edge-runtime/node-utils": patch
+"@edge-runtime/ponyfill": patch
+"@edge-runtime/primitives": patch
+"edge-runtime": patch
+"@edge-runtime/types": patch
+"@edge-runtime/user-agent": patch
+"@edge-runtime/vm": patch
+---
+
+Use valid SPDX license expression

--- a/package.json
+++ b/package.json
@@ -80,6 +80,10 @@
       "email": "matheus.frndes@gmail.com"
     },
     {
+      "name": "Simon Mathewson",
+      "email": "simon.mathewson@cosuno.de"
+    },
+    {
       "name": "Stefan Judis",
       "email": "stefanjudis@gmail.com"
     },

--- a/packages/cookies/package.json
+++ b/packages/cookies/package.json
@@ -43,7 +43,7 @@
     "prebuild": "pnpm run clean:build",
     "test": "jest"
   },
-  "license": "MPLv2",
+  "license": "MPL-2.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/feature-detector/package.json
+++ b/packages/feature-detector/package.json
@@ -46,7 +46,7 @@
     "prebuild": "pnpm run clean:build",
     "test": "jest"
   },
-  "license": "MPLv2",
+  "license": "MPL-2.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/format/package.json
+++ b/packages/format/package.json
@@ -40,7 +40,7 @@
     "prebuild": "pnpm run clean:build",
     "test": "TZ=UTC jest"
   },
-  "license": "MPLv2",
+  "license": "MPL-2.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/jest-environment/package.json
+++ b/packages/jest-environment/package.json
@@ -44,7 +44,7 @@
     "prebuild": "pnpm run clean:build",
     "test": "jest"
   },
-  "license": "MPLv2",
+  "license": "MPL-2.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/jest-expect/package.json
+++ b/packages/jest-expect/package.json
@@ -49,7 +49,7 @@
     "prebuild": "pnpm run clean:build",
     "test": "jest --no-colors"
   },
-  "license": "MPLv2",
+  "license": "MPL-2.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/node-utils/package.json
+++ b/packages/node-utils/package.json
@@ -42,7 +42,7 @@
     "prebuild": "pnpm run clean:build",
     "test": "jest"
   },
-  "license": "MPLv2",
+  "license": "MPL-2.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/ponyfill/package.json
+++ b/packages/ponyfill/package.json
@@ -46,7 +46,7 @@
     "test:edge": "EDGE_RUNTIME_EXISTS=true jest --env=@edge-runtime/jest-environment --testPathIgnorePatterns='.node.test.ts$'",
     "test:node": "jest --env=node"
   },
-  "license": "MPLv2",
+  "license": "MPL-2.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -69,7 +69,7 @@
     "prebuild": "pnpm run clean:build",
     "test": "jest"
   },
-  "license": "MPLv2",
+  "license": "MPL-2.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -52,7 +52,7 @@
     "prebuild": "pnpm run clean:build",
     "test": "jest"
   },
-  "license": "MPLv2",
+  "license": "MPL-2.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -32,7 +32,7 @@
   "files": [
     "src"
   ],
-  "license": "MPLv2",
+  "license": "MPL-2.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/user-agent/package.json
+++ b/packages/user-agent/package.json
@@ -43,7 +43,7 @@
     "prebuild": "pnpm run clean:build",
     "test": "jest"
   },
-  "license": "MPLv2",
+  "license": "MPL-2.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -38,7 +38,7 @@
     "clean:node": "rm -rf node_modules",
     "test": "jest"
   },
-  "license": "MPLv2",
+  "license": "MPL-2.0",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
This will help users with automated license checking tools.

[List of valid SPDX license expressions](https://spdx.org/licenses/)

Closes https://github.com/vercel/edge-runtime/issues/274