### PR TITLE
Upgrade `undici` to utilize `Headers.prototype.getSetCookie`

### DIFF
--- a/packages/cookies/package.json
+++ b/packages/cookies/package.json
@@ -25,6 +25,7 @@
     "web"
   ],
   "devDependencies": {
+    "@edge-runtime/primitives": "workspace:2.1.2",
     "@edge-runtime/format": "workspace:2.0.1",
     "@edge-runtime/jest-environment": "workspace:2.0.8",
     "@types/cookie": "0.5.1",

--- a/packages/cookies/src/request-cookies.ts
+++ b/packages/cookies/src/request-cookies.ts
@@ -1,5 +1,6 @@
 import type { RequestCookie } from './types'
 import { parseCookieString, serialize } from './serialize'
+import type { Headers } from '@edge-runtime/primitives'
 
 /**
  * A class for manipulating {@link Request} cookies (`Cookie` header).

--- a/packages/cookies/src/response-cookies.ts
+++ b/packages/cookies/src/response-cookies.ts
@@ -16,8 +16,8 @@ export class ResponseCookies {
     this._headers = responseHeaders
 
     const setCookie =
-      // @ts-expect-error See https://github.com/whatwg/fetch/issues/973
-      responseHeaders.getAll?.('set-cookie') ??
+      // @ts-expect-error Implemented as a part of the `@edge-runtime/primitives` package
+      responseHeaders.getSetCookie?.() ??
       responseHeaders.get('set-cookie') ??
       []
 

--- a/packages/cookies/src/response-cookies.ts
+++ b/packages/cookies/src/response-cookies.ts
@@ -1,5 +1,6 @@
 import type { ResponseCookie } from './types'
 import { parseSetCookieString, serialize } from './serialize'
+import type { Headers } from '@edge-runtime/primitives'
 
 /**
  * A class for manipulating {@link Response} cookies (`Set-Cookie` header).
@@ -16,7 +17,6 @@ export class ResponseCookies {
     this._headers = responseHeaders
 
     const setCookie =
-      // @ts-expect-error Implemented as a part of the `@edge-runtime/primitives` package
       responseHeaders.getSetCookie?.() ??
       responseHeaders.get('set-cookie') ??
       []

--- a/packages/cookies/test/response-cookies.test.ts
+++ b/packages/cookies/test/response-cookies.test.ts
@@ -1,4 +1,5 @@
 import { createFormat } from '@edge-runtime/format'
+import { Headers } from '@edge-runtime/primitives'
 import { ResponseCookies } from '../src/response-cookies'
 
 test('reflect .set into `set-cookie`', async () => {
@@ -51,8 +52,17 @@ test('reflect .set into `set-cookie`', async () => {
     expires: new Date(0),
   })
 
-  expect(Object.fromEntries(headers.entries())['set-cookie']).toBe(
-    'foo=bar; Path=/test, fooz=barz; Path=/test2, fooHttpOnly=barHttpOnly; Path=/; HttpOnly, fooExpires=barExpires; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT, fooExpiresDate=barExpiresDate; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT'
+  const setCookieHeaders = headers.getSetCookie?.()
+  expect(setCookieHeaders).toContain('foo=bar; Path=/test')
+  expect(setCookieHeaders).toContain('fooz=barz; Path=/test2')
+  expect(setCookieHeaders).toContain(
+    'fooHttpOnly=barHttpOnly; Path=/; HttpOnly'
+  )
+  expect(setCookieHeaders).toContain(
+    'fooExpires=barExpires; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT'
+  )
+  expect(setCookieHeaders).toContain(
+    'fooExpiresDate=barExpiresDate; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT'
   )
 })
 
@@ -73,9 +83,9 @@ test('reflect .delete into `set-cookie`', async () => {
   })
 
   cookies.set('fooz', 'barz')
-  expect(Object.fromEntries(headers.entries())['set-cookie']).toBe(
-    'foo=bar; Path=/, fooz=barz; Path=/'
-  )
+  let setCookieHeaders = headers.getSetCookie?.()
+  expect(setCookieHeaders).toContain('foo=bar; Path=/')
+  expect(setCookieHeaders).toContain('fooz=barz; Path=/')
 
   expect(cookies.get('fooz')?.value).toBe('barz')
   expect(cookies.get('fooz')).toEqual({
@@ -85,9 +95,11 @@ test('reflect .delete into `set-cookie`', async () => {
   })
 
   cookies.delete('foo')
-  expect(Object.fromEntries(headers.entries())['set-cookie']).toBe(
-    'foo=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT, fooz=barz; Path=/'
+  setCookieHeaders = headers.getSetCookie?.()
+  expect(setCookieHeaders).toContain(
+    'foo=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT'
   )
+  expect(setCookieHeaders).toContain('fooz=barz; Path=/')
 
   expect(cookies.get('foo')).toEqual({
     name: 'foo',
@@ -98,8 +110,12 @@ test('reflect .delete into `set-cookie`', async () => {
 
   cookies.delete('fooz')
 
-  expect(Object.fromEntries(headers.entries())['set-cookie']).toBe(
-    'foo=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT, fooz=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT'
+  setCookieHeaders = headers.getSetCookie?.()
+  expect(setCookieHeaders).toContain(
+    'foo=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT'
+  )
+  expect(setCookieHeaders).toContain(
+    'fooz=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT'
   )
 
   expect(cookies.get('fooz')).toEqual({

--- a/packages/jest-environment/src/index.ts
+++ b/packages/jest-environment/src/index.ts
@@ -125,6 +125,7 @@ function revealPrimitives(vm: EdgeVM<any>) {
     'String',
     'Symbol',
     'SyntaxError',
+    'setImmediate',
     'TypeError',
     'Uint8Array',
     'Uint8ClampedArray',

--- a/packages/node-utils/src/edge-to-node/headers.ts
+++ b/packages/node-utils/src/edge-to-node/headers.ts
@@ -12,7 +12,7 @@ export function toOutgoingHeaders(
       outputHeaders[name] = value
       if (name.toLowerCase() === 'set-cookie') {
         outputHeaders[name] =
-          headers.getAll?.('set-cookie') ?? splitCookiesString(value)
+          headers.getSetCookie?.() ?? splitCookiesString(value)
       }
     }
   }
@@ -36,7 +36,7 @@ export function mergeIntoServerResponse(
   This is uncommon, but explicitly allowed - see https://tools.ietf.org/html/rfc2616#section-4.2
   Node.js does this for every header *except* set-cookie - see https://github.com/nodejs/node/blob/d5e363b77ebaf1caf67cd7528224b651c86815c1/lib/_http_incoming.js#L128
   React Native's fetch does this for *every* header, including set-cookie.
-  
+
   Based on: https://github.com/google/j2objc/commit/16820fdbc8f76ca0c33472810ce0cb03d20efe25
   Credits to: https://github.com/tomball for original and https://github.com/chrusart for JavaScript implementation
 */

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -39,7 +39,7 @@
     "test-listen": "1.1.0",
     "text-encoding": "0.7.0",
     "tsup": "6",
-    "undici": "5.11.0",
+    "undici": "5.20.0",
     "urlpattern-polyfill": "6.0.2",
     "web-streams-polyfill": "4.0.0-beta.3",
     "whatwg-url": "12.0.0"

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -39,7 +39,7 @@
     "test-listen": "1.1.0",
     "text-encoding": "0.7.0",
     "tsup": "6",
-    "undici": "5.20.0",
+    "undici": "5.21.0",
     "urlpattern-polyfill": "6.0.2",
     "web-streams-polyfill": "4.0.0-beta.3",
     "whatwg-url": "12.0.0"

--- a/packages/primitives/src/primitives/fetch.js
+++ b/packages/primitives/src/primitives/fetch.js
@@ -1,12 +1,9 @@
 import { AbortController } from './abort-controller'
 import { AbortSignal } from './abort-controller'
 
-import * as CoreSymbols from 'undici/lib/core/symbols'
 import * as FetchSymbols from 'undici/lib/fetch/symbols'
 import * as HeadersModule from 'undici/lib/fetch/headers'
 import * as ResponseModule from 'undici/lib/fetch/response'
-import * as UtilModule from 'undici/lib/fetch/util'
-import * as WebIDLModule from 'undici/lib/fetch/webidl'
 
 import { fetch as fetchImpl } from 'undici/lib/fetch'
 import Agent from 'undici/lib/agent'
@@ -19,95 +16,6 @@ global.AbortSignal = AbortSignal
 process.nextTick = setImmediate
 
 /**
- * A symbol used to store cookies in the headers module.
- */
-const SCookies = Symbol('set-cookie')
-
-/**
- * Patch HeadersList.append so that when a `set-cookie` header is appended
- * we keep it in an list to allow future retrieval of all values.
- */
-const __append = HeadersModule.HeadersList.prototype.append
-HeadersModule.HeadersList.prototype.append = function (name, value) {
-  const result = __append.call(this, name, value)
-  if (!this[SCookies]) {
-    Object.defineProperty(this, SCookies, {
-      configurable: false,
-      enumerable: false,
-      writable: true,
-      value: [],
-    })
-  }
-
-  const _name = normalizeAndValidateHeaderValue(name, 'Header.append')
-  if (_name === 'set-cookie') {
-    this[SCookies].push(normalizeAndValidateHeaderValue(value, 'Header.append'))
-  }
-
-  return result
-}
-
-/**
- * Patch HeadersList.set to make sure that when a new value for `set-cookie`
- * is set it will also entirely replace the internal list of values.
- */
-const __set = HeadersModule.HeadersList.prototype.set
-HeadersModule.HeadersList.prototype.set = function (name, value) {
-  const result = __set.call(this, name, value)
-  if (!this[SCookies]) {
-    Object.defineProperty(this, SCookies, {
-      configurable: false,
-      enumerable: false,
-      writable: true,
-      value: [],
-    })
-  }
-
-  const _name = normalizeAndValidateHeaderName(name)
-  if (_name === 'set-cookie') {
-    this[SCookies] = [normalizeAndValidateHeaderValue(value, 'HeadersList.set')]
-  }
-
-  return result
-}
-
-/**
- * Patch HeaderList.delete to make sure that when `set-cookie` is cleared
- * we also remove the internal list values.
- */
-const __delete = HeadersModule.HeadersList.prototype.delete
-HeadersModule.HeadersList.prototype.delete = function (name) {
-  __delete.call(this, name)
-  if (!this[SCookies]) {
-    Object.defineProperty(this, SCookies, {
-      configurable: false,
-      enumerable: false,
-      writable: true,
-      value: [],
-    })
-  }
-
-  const _name = normalizeAndValidateHeaderName(name, 'Headers.delete')
-  if (_name === 'set-cookie') {
-    this[SCookies] = []
-  }
-}
-
-/**
- * Add a new method for retrieving all independent `set-cookie` headers that
- * maybe have been appended. This will only work when getting `set-cookie`
- * headers.
- */
-HeadersModule.Headers.prototype.getAll = function (name) {
-  const _name = normalizeAndValidateHeaderName(name, 'Headers.getAll')
-  if (_name !== 'set-cookie') {
-    throw new Error(`getAll can only be used with 'set-cookie'`)
-  }
-
-  return this[CoreSymbols.kHeadersList][SCookies] || []
-}
-
-/**
  * We also must patch the error static method since it works just like
  * redirect and we need consistency.
  */
@@ -116,55 +24,6 @@ ResponseModule.Response.error = function (...args) {
   const response = __error.call(this, ...args)
   response[FetchSymbols.kHeaders][FetchSymbols.kGuard] = 'response'
   return response
-}
-
-/**
- * normalize header name per WHATWG spec, and validate
- *
- * @param {string} potentialName
- * @param {'Header.append' | 'Headers.delete' | 'Headers.get' | 'Headers.has' | 'Header.set'} errorPrefix
- */
-function normalizeAndValidateHeaderName(potentialName, errorPrefix) {
-  const normalizedName = potentialName.toLowerCase()
-
-  if (UtilModule.isValidHeaderName(normalizedName)) {
-    return normalizedName
-  }
-
-  // Generate an WHATWG fetch spec compliant error
-  WebIDLModule.errors.invalidArgument({
-    prefix: errorPrefix,
-    value: normalizedName,
-    type: 'header name',
-  })
-}
-
-/**
- * normalize header value per WHATWG spec, and validate
- *
- * @param {string} potentialValue
- * @param {'Header.append' | 'Header.set'} errorPrefix
- */
-function normalizeAndValidateHeaderValue(potentialValue, errorPrefix) {
-  /**
-   * To normalize a byte sequence potentialValue, remove
-   * any leading and trailing HTTP whitespace bytes from
-   *  potentialValue.
-   *
-   * See https://fetch.spec.whatwg.org/#concept-header-value-normalize
-   */
-  const normalizedValue = potentialValue.replace(/^[\r\n\t ]+|[\r\n\t ]+$/g, '')
-
-  if (UtilModule.isValidHeaderValue(normalizedValue)) {
-    return normalizedValue
-  }
-
-  // Generate an WHATWG fetch spec compliant error
-  WebIDLModule.errors.invalidArgument({
-    prefix: errorPrefix,
-    value: normalizedValue,
-    type: 'header value',
-  })
 }
 
 /**

--- a/packages/primitives/src/primitives/fetch.js
+++ b/packages/primitives/src/primitives/fetch.js
@@ -2,7 +2,6 @@ import { AbortController } from './abort-controller'
 import { AbortSignal } from './abort-controller'
 
 import * as FetchSymbols from 'undici/lib/fetch/symbols'
-import * as HeadersModule from 'undici/lib/fetch/headers'
 import * as ResponseModule from 'undici/lib/fetch/response'
 
 import { fetch as fetchImpl } from 'undici/lib/fetch'
@@ -55,9 +54,9 @@ export async function fetch() {
   return response
 }
 
-export const Headers = HeadersModule.Headers
 export const Response = ResponseModule.Response
 
 export { FormData } from 'undici/lib/fetch/formdata'
 export { Request } from 'undici/lib/fetch/request'
+export { Headers } from 'undici/lib/fetch/headers'
 export { File } from 'undici/lib/fetch/file'

--- a/packages/primitives/tests/headers.test.ts
+++ b/packages/primitives/tests/headers.test.ts
@@ -10,3 +10,14 @@ test('sets header calling Headers constructor', async () => {
   headers.set('cookie', 'hello=world')
   expect(headers.get('cookie')).toBe('hello=world')
 })
+
+test('append works for "set-cookie"', function () {
+  const headers = new Headers()
+  headers.append('set-cookie', 'foo=bar')
+  headers.append('set-cookie', 'fizz=buzz')
+  const list = [...headers]
+  expect(list).toEqual([
+    ['set-cookie', 'foo=bar'],
+    ['set-cookie', 'fizz=buzz'],
+  ])
+})

--- a/packages/primitives/tests/response.test.ts
+++ b/packages/primitives/tests/response.test.ts
@@ -10,7 +10,7 @@ test('allow to append multiple `set-cookie` header', async () => {
   const response = new Response(null)
   response.headers.append('set-cookie', 'foo=bar')
   response.headers.append('set-cookie', 'bar=baz')
-  expect(response.headers.getAll('set-cookie')).toEqual(['foo=bar', 'bar=baz'])
+  expect(response.headers.getSetCookie?.()).toEqual(['foo=bar', 'bar=baz'])
 })
 
 test('disallow mutate response headers for redirects', async () => {

--- a/packages/primitives/type-definitions/fetch.d.ts
+++ b/packages/primitives/type-definitions/fetch.d.ts
@@ -11,8 +11,8 @@ export class Response extends globalThis.Response {
   static json(data: any, init?: ResponseInit): Response
 }
 
-export type RequestInfo = Parameters<typeof fetch>[0]
-export type RequestInit = Parameters<typeof fetch>[1]
+type RequestInfo = globalThis.RequestInfo | URL
+type RequestInit = globalThis.RequestInit | undefined
 declare const fetchImplementation: (
   info: RequestInfo,
   init?: RequestInit

--- a/packages/primitives/type-definitions/fetch.d.ts
+++ b/packages/primitives/type-definitions/fetch.d.ts
@@ -1,5 +1,5 @@
 export class Headers extends globalThis.Headers {
-  getAll?(key: 'set-cookie'): string[]
+  getSetCookie?(): string[]
 }
 
 export class Request extends globalThis.Request {

--- a/packages/vm/src/edge-vm.ts
+++ b/packages/vm/src/edge-vm.ts
@@ -87,6 +87,7 @@ function addPrimitives(context: VMContext) {
   defineProperty(context, 'Symbol', { value: Symbol })
   defineProperty(context, 'clearInterval', { value: clearInterval })
   defineProperty(context, 'clearTimeout', { value: clearTimeout })
+  defineProperty(context, 'setImmediate', { value: setImmediate })
   defineProperty(context, 'setInterval', { value: setInterval })
   defineProperty(context, 'setTimeout', { value: setTimeout })
   defineProperty(context, 'EdgeRuntime', { value: 'edge-runtime' })

--- a/packages/vm/src/edge-vm.ts
+++ b/packages/vm/src/edge-vm.ts
@@ -179,6 +179,7 @@ function addPrimitives(context: VMContext) {
       ['http', { exports: require('http') }],
       ['net', { exports: require('net') }],
       ['perf_hooks', { exports: require('perf_hooks') }],
+      ['worker_threads', { exports: require('worker_threads') }],
       ['querystring', { exports: require('querystring') }],
       ['stream', { exports: require('stream') }],
       ['tls', { exports: require('tls') }],

--- a/packages/vm/src/edge-vm.ts
+++ b/packages/vm/src/edge-vm.ts
@@ -180,6 +180,7 @@ function addPrimitives(context: VMContext) {
       ['net', { exports: require('net') }],
       ['perf_hooks', { exports: require('perf_hooks') }],
       ['worker_threads', { exports: require('worker_threads') }],
+      ['url', { exports: require('url') }],
       ['querystring', { exports: require('querystring') }],
       ['stream', { exports: require('stream') }],
       ['tls', { exports: require('tls') }],

--- a/packages/vm/src/edge-vm.ts
+++ b/packages/vm/src/edge-vm.ts
@@ -105,7 +105,10 @@ function addPrimitives(context: VMContext) {
   const encodings = requireWithCache({
     context,
     path: require.resolve('@edge-runtime/primitives/encoding'),
-    scopedContext: { Buffer, global: {} },
+    scopedContext: {
+      Buffer,
+      global: { ArrayBuffer },
+    },
   })
 
   // Encoding APIs
@@ -201,6 +204,8 @@ function addPrimitives(context: VMContext) {
       queueMicrotask,
       setImmediate,
       clearImmediate,
+      TextEncoder: encodings.TextEncoder,
+      TextDecoder: encodings.TextDecoder,
     },
   })
 

--- a/packages/vm/tests/integration/body.test.ts
+++ b/packages/vm/tests/integration/body.test.ts
@@ -198,12 +198,13 @@ test('throws when reading a text body as JSON but it is invalid', async () => {
   const response = new Response('{ hi: "there", ')
   const error = await response.json().catch((err) => err)
   expect(error).toBeInstanceOf(SyntaxError)
-  expect(error.message).toEqual('Unexpected token h in JSON at position 2')
+  expect(error.message).toEqual('Unexpected end of JSON input')
 })
 
 test('streams Uint8Array that can be decoded into a string', async () => {
   const response = await fetch('https://example.vercel.sh')
-  const reader = response.body.getReader()
+  expect(response.body).not.toBeNull()
+  const reader = response.body!.getReader()
   let value: string = ''
   const decoder = new TextDecoder()
   while (true) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,7 @@ importers:
       turbo: latest
       typescript: latest
     devDependencies:
-      '@changesets/cli': 2.26.1
+      '@changesets/cli': 2.26.0
       '@jest/types': 29.1.2
       '@svitejs/changesets-changelog-github-compact': 1.1.0
       '@types/jest': 29.0.3
@@ -35,11 +35,11 @@ importers:
       jest: 29.5.0_4f2ldd7um3b3u4eyvetyqsphze
       jest-watch-typeahead: 2.2.1_jest@29.5.0
       nano-staged: 0.8.0
-      prettier: 2.8.7
+      prettier: 2.7.1
       simple-git-hooks: 2.8.1
       ts-jest: 29.0.5_64vaa66jjn6p2sqcklvuluufju
       ts-node: 10.9.1_v2peit2ignagqkesbarskbvag4
-      turbo: 1.8.5
+      turbo: 1.6.3
       typescript: 5.0.2
 
   docs:
@@ -185,7 +185,7 @@ importers:
       test-listen: 1.1.0
       text-encoding: 0.7.0
       tsup: '6'
-      undici: 5.11.0
+      undici: 5.20.0
       urlpattern-polyfill: 6.0.2
       web-streams-polyfill: 4.0.0-beta.3
       whatwg-url: 12.0.0
@@ -206,7 +206,7 @@ importers:
       test-listen: 1.1.0
       text-encoding: 0.7.0
       tsup: 6.2.2
-      undici: 5.11.0
+      undici: 5.20.0
       urlpattern-polyfill: 6.0.2
       web-streams-polyfill: 4.0.0-beta.3
       whatwg-url: 12.0.0
@@ -584,7 +584,7 @@ packages:
       fs-extra: 7.0.1
       lodash.startcase: 4.4.0
       outdent: 0.5.0
-      prettier: 2.8.7
+      prettier: 2.7.1
       resolve-from: 5.0.0
       semver: 5.7.1
     dev: true
@@ -606,8 +606,8 @@ packages:
       '@changesets/types': 5.2.1
     dev: true
 
-  /@changesets/cli/2.26.1:
-    resolution: {integrity: sha512-XnTa+b51vt057fyAudvDKGB0Sh72xutQZNAdXkCqPBKO2zvs2yYZx5hFZj1u9cbtpwM6Sxtcr02/FQJfZOzemQ==}
+  /@changesets/cli/2.26.0:
+    resolution: {integrity: sha512-0cbTiDms+ICTVtEwAFLNW0jBNex9f5+fFv3I771nBvdnV/mOjd1QJ4+f8KtVSOrwD9SJkk9xbDkWFb0oXd8d1Q==}
     hasBin: true
     dependencies:
       '@babel/runtime': 7.20.13
@@ -761,7 +761,7 @@ packages:
       '@changesets/types': 5.2.1
       fs-extra: 7.0.1
       human-id: 1.0.2
-      prettier: 2.8.7
+      prettier: 2.7.1
     dev: true
 
   /@cspotcode/source-map-support/0.8.1:
@@ -7371,8 +7371,8 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /prettier/2.8.7:
-    resolution: {integrity: sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==}
+  /prettier/2.7.1:
+    resolution: {integrity: sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     dev: true
@@ -7871,14 +7871,6 @@ packages:
   /semver/6.3.0:
     resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
     hasBin: true
-
-  /semver/7.3.7:
-    resolution: {integrity: sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dependencies:
-      lru-cache: 6.0.0
-    dev: true
 
   /semver/7.3.8:
     resolution: {integrity: sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==}
@@ -8493,7 +8485,7 @@ packages:
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
-      semver: 7.3.7
+      semver: 7.3.8
       typescript: 5.0.2
       yargs-parser: 21.1.1
     dev: true
@@ -8628,65 +8620,65 @@ packages:
       yargs: 17.6.2
     dev: true
 
-  /turbo-darwin-64/1.8.5:
-    resolution: {integrity: sha512-CAYh56bzeHfnh7jTm03r29bh8p5a/EjQo1Id5yLUH7hS7msTau/+YpxJWPodLbN0UQsUYivUqHQkglJ+eMJ7xA==}
+  /turbo-darwin-64/1.6.3:
+    resolution: {integrity: sha512-QmDIX0Yh1wYQl0bUS0gGWwNxpJwrzZU2GIAYt3aOKoirWA2ecnyb3R6ludcS1znfNV2MfunP+l8E3ncxUHwtjA==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-darwin-arm64/1.8.5:
-    resolution: {integrity: sha512-R3jCPOv+lu3dcvMhj8b/Defv6dyUwX6W+tbX7d6YUCA46Plf/bGCQ8+MSbxmr/4E1GyGOVFsn1wRfiYk0us/Dg==}
+  /turbo-darwin-arm64/1.6.3:
+    resolution: {integrity: sha512-75DXhFpwE7CinBbtxTxH08EcWrxYSPFow3NaeFwsG8aymkWXF+U2aukYHJA6I12n9/dGqf7yRXzkF0S/9UtdyQ==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-64/1.8.5:
-    resolution: {integrity: sha512-YRc/KNRZeUVvth11UO4SDQZR2IqGgl9MSsbzqoHuFz4B4Q5QXH7onHogv9aXWE/BZBBbcrSBTlwBSG0Gg+J8hg==}
+  /turbo-linux-64/1.6.3:
+    resolution: {integrity: sha512-O9uc6J0yoRPWdPg9THRQi69K6E2iZ98cRHNvus05lZbcPzZTxJYkYGb5iagCmCW/pq6fL4T4oLWAd6evg2LGQA==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-arm64/1.8.5:
-    resolution: {integrity: sha512-8exVZb7XBl/V3gHSweuUyG2D9IzfWqwLvlXoeLWlVYSj61Ajgdv+WU7lvUmx+H2s+sSKqmIFmewA5Lw6YY37sg==}
+  /turbo-linux-arm64/1.6.3:
+    resolution: {integrity: sha512-dCy667qqEtZIhulsRTe8hhWQNCJO0i20uHXv7KjLHuFZGCeMbWxB8rsneRoY+blf8+QNqGuXQJxak7ayjHLxiA==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-64/1.8.5:
-    resolution: {integrity: sha512-fA8PU5ZNoFnQkapG06WiEqfsVQ5wbIPkIqTwUsd/M2Lp+KgxE79SQbuEI+2vQ9SmwM5qoMi515IPjgvXAJXgCw==}
+  /turbo-windows-64/1.6.3:
+    resolution: {integrity: sha512-lKRqwL3mrVF09b9KySSaOwetehmGknV9EcQTF7d2dxngGYYX1WXoQLjFP9YYH8ZV07oPm+RUOAKSCQuDuMNhiA==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-arm64/1.8.5:
-    resolution: {integrity: sha512-SW/NvIdhckLsAWjU/iqBbCB0S8kXupKscUK3kEW1DZIr3MYcP/yIuaE/IdPuqcoF3VP0I3TLD4VTYCCKAo3tKA==}
+  /turbo-windows-arm64/1.6.3:
+    resolution: {integrity: sha512-BXY1sDPEA1DgPwuENvDCD8B7Hb0toscjus941WpL8CVd10hg9pk/MWn9CNgwDO5Q9ks0mw+liDv2EMnleEjeNA==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo/1.8.5:
-    resolution: {integrity: sha512-UBnH2wIFb5g6OQCk8f34Ud15ZXV4xEMmugeDJTU5Ur2LpVRsNEny0isSCYdb3Iu3howoNyyXmtpaxWsAwNYkkg==}
+  /turbo/1.6.3:
+    resolution: {integrity: sha512-FtfhJLmEEtHveGxW4Ye/QuY85AnZ2ZNVgkTBswoap7UMHB1+oI4diHPNyqrQLG4K1UFtCkjOlVoLsllUh/9QRw==}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      turbo-darwin-64: 1.8.5
-      turbo-darwin-arm64: 1.8.5
-      turbo-linux-64: 1.8.5
-      turbo-linux-arm64: 1.8.5
-      turbo-windows-64: 1.8.5
-      turbo-windows-arm64: 1.8.5
+      turbo-darwin-64: 1.6.3
+      turbo-darwin-arm64: 1.6.3
+      turbo-linux-64: 1.6.3
+      turbo-linux-arm64: 1.6.3
+      turbo-windows-64: 1.6.3
+      turbo-windows-arm64: 1.6.3
     dev: true
 
   /type-detect/4.0.8:
@@ -8782,8 +8774,8 @@ packages:
     resolution: {integrity: sha512-z4o1fvKUojIWh9XuaVLUDdf86RQiq13AC1dmHbTpoyuu+bquHms76v16CjycCbec87J7z0k//SiQVk0sMdFmpQ==}
     dev: true
 
-  /undici/5.11.0:
-    resolution: {integrity: sha512-oWjWJHzFet0Ow4YZBkyiJwiK5vWqEYoH7BINzJAJOLedZ++JpAlCbUktW2GQ2DS2FpKmxD/JMtWUUWl1BtghGw==}
+  /undici/5.20.0:
+    resolution: {integrity: sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==}
     engines: {node: '>=12.18'}
     dependencies:
       busboy: 1.6.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,7 +187,7 @@ importers:
       test-listen: 1.1.0
       text-encoding: 0.7.0
       tsup: '6'
-      undici: 5.20.0
+      undici: 5.21.0
       urlpattern-polyfill: 6.0.2
       web-streams-polyfill: 4.0.0-beta.3
       whatwg-url: 12.0.0
@@ -208,7 +208,7 @@ importers:
       test-listen: 1.1.0
       text-encoding: 0.7.0
       tsup: 6.2.2
-      undici: 5.20.0
+      undici: 5.21.0
       urlpattern-polyfill: 6.0.2
       web-streams-polyfill: 4.0.0-beta.3
       whatwg-url: 12.0.0
@@ -8776,8 +8776,8 @@ packages:
     resolution: {integrity: sha512-z4o1fvKUojIWh9XuaVLUDdf86RQiq13AC1dmHbTpoyuu+bquHms76v16CjycCbec87J7z0k//SiQVk0sMdFmpQ==}
     dev: true
 
-  /undici/5.20.0:
-    resolution: {integrity: sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==}
+  /undici/5.21.0:
+    resolution: {integrity: sha512-HOjK8l6a57b2ZGXOcUsI5NLfoTrfmbOl90ixJDl0AEFG4wgHNDQxtZy15/ZQp7HhjkpaGlp/eneMgtsu1dIlUA==}
     engines: {node: '>=12.18'}
     dependencies:
       busboy: 1.6.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,11 +73,13 @@ importers:
     specifiers:
       '@edge-runtime/format': workspace:2.0.1
       '@edge-runtime/jest-environment': workspace:2.0.8
+      '@edge-runtime/primitives': workspace:2.1.2
       '@types/cookie': 0.5.1
       tsup: '6'
     devDependencies:
       '@edge-runtime/format': link:../format
       '@edge-runtime/jest-environment': link:../jest-environment
+      '@edge-runtime/primitives': link:../primitives
       '@types/cookie': 0.5.1
       tsup: 6.2.2
 


### PR DESCRIPTION
This upgrades `undici` so we can utilize `Headers.prototype.getSetCookie`. This replaces the custom functionality provided by `getAll`.