### PR TITLE
fix(cookies): accept `DOMHighResTimeStamp` on expires of cookie

### DIFF
--- a/.changeset/honest-worms-add.md
+++ b/.changeset/honest-worms-add.md
@@ -1,0 +1,5 @@
+---
+'@edge-runtime/cookies': patch
+---
+
+Accept `DOMHighResTimeStamp` on expires of cookie

--- a/packages/cookies/src/response-cookies.ts
+++ b/packages/cookies/src/response-cookies.ts
@@ -98,6 +98,10 @@ function replace(bag: Map<string, ResponseCookie>, headers: Headers) {
 }
 
 function normalizeCookie(cookie: ResponseCookie = { name: '', value: '' }) {
+  if (typeof cookie.expires === 'number') {
+    cookie.expires = new Date(cookie.expires)
+  }
+
   if (cookie.maxAge) {
     cookie.expires = new Date(Date.now() + cookie.maxAge * 1000)
   }

--- a/packages/cookies/src/serialize.ts
+++ b/packages/cookies/src/serialize.ts
@@ -3,7 +3,12 @@ import type { RequestCookie, ResponseCookie } from './types'
 export function serialize(c: ResponseCookie | RequestCookie): string {
   const attrs = [
     'path' in c && c.path && `Path=${c.path}`,
-    'expires' in c && c.expires && `Expires=${c.expires.toUTCString()}`,
+    'expires' in c &&
+      (c.expires || c.expires === 0) &&
+      `Expires=${(typeof c.expires === 'number'
+        ? new Date(c.expires)
+        : c.expires
+      ).toUTCString()}`,
     'maxAge' in c && c.maxAge && `Max-Age=${c.maxAge}`,
     'domain' in c && c.domain && `Domain=${c.domain}`,
     'secure' in c && c.secure && 'Secure',

--- a/packages/cookies/src/types.ts
+++ b/packages/cookies/src/types.ts
@@ -7,12 +7,14 @@ import type { CookieSerializeOptions } from 'cookie'
 export interface CookieListItem
   extends Pick<
     CookieSerializeOptions,
-    'domain' | 'path' | 'expires' | 'secure' | 'sameSite'
+    'domain' | 'path' | 'secure' | 'sameSite'
   > {
   /** A string with the name of a cookie. */
   name: string
   /** A string containing the value of the cookie. */
   value: string
+  /** A number of milliseconds or Date interface containing the expires of the cookie. */
+  expires?: number | CookieSerializeOptions['expires']
 }
 
 /**

--- a/packages/cookies/test/response-cookies.test.ts
+++ b/packages/cookies/test/response-cookies.test.ts
@@ -12,10 +12,14 @@ test('reflect .set into `set-cookie`', async () => {
     .set('foo', 'bar', { path: '/test' })
     .set('fooz', 'barz', { path: '/test2' })
     .set('fooHttpOnly', 'barHttpOnly', { httpOnly: true })
+    .set('fooExpires', 'barExpires', { expires: 0 })
+    .set('fooExpiresDate', 'barExpiresDate', { expires: new Date(0) })
 
   expect(cookies.get('foo')?.value).toBe('bar')
   expect(cookies.get('fooz')?.value).toBe('barz')
   expect(cookies.get('fooHttpOnly')?.value).toBe('barHttpOnly')
+  expect(cookies.get('fooExpires')?.value).toBe('barExpires')
+  expect(cookies.get('fooExpiresDate')?.value).toBe('barExpiresDate')
 
   const opt1 = cookies.get('foo')
   expect(opt1).toEqual<typeof opt1>({
@@ -34,9 +38,21 @@ test('reflect .set into `set-cookie`', async () => {
     path: '/',
     httpOnly: true,
   })
+  expect(cookies.get('fooExpires')).toEqual({
+    name: 'fooExpires',
+    value: 'barExpires',
+    path: '/',
+    expires: new Date(0),
+  })
+  expect(cookies.get('fooExpiresDate')).toEqual({
+    name: 'fooExpiresDate',
+    value: 'barExpiresDate',
+    path: '/',
+    expires: new Date(0),
+  })
 
   expect(Object.fromEntries(headers.entries())['set-cookie']).toBe(
-    'foo=bar; Path=/test, fooz=barz; Path=/test2, fooHttpOnly=barHttpOnly; Path=/; HttpOnly'
+    'foo=bar; Path=/test, fooz=barz; Path=/test2, fooHttpOnly=barHttpOnly; Path=/; HttpOnly, fooExpires=barExpires; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT, fooExpiresDate=barExpiresDate; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT'
   )
 })
 


### PR DESCRIPTION
According to the [W3C CookieStore API spec](https://wicg.github.io/cookie-store/#dictdef-cookielistitem), expires accepts [`DOMHighResTimeStamp`](https://w3c.github.io/hr-time/#dom-domhighrestimestamp) but `@edge-runtime/cookies` only accepts `Date` interface. Change to accept both `DOMHighResTimeStamp` and `Date` interface for backwards compatibility instead of replacing `Date` interface.