### PR TITLE
docs(getting-started): improve example

### DIFF
--- a/docs/pages/getting-started.mdx
+++ b/docs/pages/getting-started.mdx
@@ -37,7 +37,7 @@ Once it's installed, you can evaluate any script into the runtime context:
 import { EdgeRuntime } from 'edge-runtime'
 
 const runtime = new EdgeRuntime()
-const result = await runtime.evaluate("fetch('https://example.com')")
+const result = await runtime.evaluate("fetch('https://example.vercel.sh')")
 
 console.log(result)
 ```
@@ -67,32 +67,31 @@ const result = await runtime.evaluate("fetch('example.com')")
 console.log(result)
 ```
 
-You can also load some initial code and interact with it as a regular HTTP server:
+You can load some initial code, for example, to be ready for receiving fetch events:
 
 ```js
 import { EdgeRuntime } from 'edge-runtime'
 
 const initialCode = `
 addEventListener('fetch', event => {
-  const { searchParams } = new URL(event.request.url)
-  const url = searchParams.get('url')
-  return event.respondWith(fetch(url))
+  return event.respondWith(fetch(event.request.url))
 })`
 
 const edgeRuntime = new EdgeRuntime({ initialCode })
-
-const response = await edgeRuntime.dispatchFetch('https://example.com')
+const response = await edgeRuntime.dispatchFetch('https://example.vercel.sh')
 
 // If your code logic performs asynchronous tasks, you should await them.
 // https://developer.mozilla.org/en-US/docs/Web/API/ExtendableEvent/waitUntil
 await response.waitUntil()
+
+console.log(await response.text())
 ```
 
-To expose the server:
+and expose it locally to be used via HTTP:
 
 ```js
 import { EdgeRuntime, runServer } from 'edge-runtime'
-import exitHook from 'exit-hook'
+import { onExit } from 'signal-exit'
 import fetch from 'node-fetch'
 
 const initialCode = `
@@ -104,9 +103,13 @@ addEventListener('fetch', event => {
 
 const edgeRuntime = new EdgeRuntime({ initialCode })
 
-const server = await runServer({ runtime: edgeRuntime })
+const server = await runServer({ runtime: edgeRuntime, port: 3000 })
+console.log(`> Edge server running at ${server.url}`)
+onExit(() => server.close())
+```
 
-exitHook(server.close)
+After that, you will be ready to hit your local server from your terminal:
 
-const response = await fetch(server.url)
+```
+curl http://[::]:3000?url=https://example.vercel.sh
 ```

--- a/docs/pages/packages/runtime.mdx
+++ b/docs/pages/packages/runtime.mdx
@@ -49,7 +49,7 @@ addEventListener('fetch', event => {
 const runtime = new EdgeRuntime({ initialCode })
 
 const response = await runtime.dispatchFetch(
-  'http://vercel.com?url=https://example.com'
+  'http://vercel.com?url=https://example.vercel.sh'
 )
 
 // If your code logic performs asynchronous tasks, you should await them.

--- a/packages/runtime/examples/cache.js
+++ b/packages/runtime/examples/cache.js
@@ -3,7 +3,7 @@
 async function handleRequest(event) {
   const cache = await caches.open('default')
   const { searchParams } = new URL(event.request.url)
-  const url = searchParams.get('url') || 'https://example.com'
+  const url = searchParams.get('url') || 'https://example.vercel.sh'
 
   const cacheKey = new URL(url).toString()
   const request = new Request(cacheKey)

--- a/packages/runtime/examples/fetch.js
+++ b/packages/runtime/examples/fetch.js
@@ -65,6 +65,6 @@ async function fetchRequest(url) {
 
 addEventListener('fetch', (event) => {
   const { searchParams } = new URL(event.request.url)
-  const url = searchParams.get('url') || 'https://example.com'
+  const url = searchParams.get('url') || 'https://example.vercel.s'
   return event.respondWith(fetchRequest(url))
 })

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -27,11 +27,11 @@
     "@edge-runtime/format": "workspace:*",
     "@edge-runtime/vm": "workspace:*",
     "async-listen": "2.0.3",
-    "exit-hook": "2.2.1",
     "mri": "1.2.0",
     "picocolors": "1.0.0",
     "pretty-bytes": "5.6.0",
     "pretty-ms": "7.0.1",
+    "signal-exit": "4.0.1",
     "time-span": "4.0.0"
   },
   "devDependencies": {

--- a/packages/runtime/src/cli/index.ts
+++ b/packages/runtime/src/cli/index.ts
@@ -5,7 +5,7 @@ import { promisify } from 'util'
 import { readFileSync } from 'fs'
 import { runServer, type EdgeRuntimeServer } from '../server'
 import childProcess from 'child_process'
-import exitHook from 'exit-hook'
+import { onExit } from 'signal-exit'
 import mri from 'mri'
 import path from 'path'
 
@@ -91,7 +91,7 @@ async function main() {
     }
   }
 
-  exitHook(() => server?.close())
+  onExit(() => server?.close())
   logger(`Waiting incoming requests at ${logger.quotes(server.url)}`)
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,22 +198,22 @@ importers:
       '@edge-runtime/vm': workspace:*
       '@types/node-fetch': '2'
       async-listen: 2.0.3
-      exit-hook: 2.2.1
       mri: 1.2.0
       node-fetch: '2'
       picocolors: 1.0.0
       pretty-bytes: 5.6.0
       pretty-ms: 7.0.1
+      signal-exit: 4.0.1
       time-span: 4.0.0
     dependencies:
       '@edge-runtime/format': link:../format
       '@edge-runtime/vm': link:../vm
       async-listen: 2.0.3
-      exit-hook: 2.2.1
       mri: 1.2.0
       picocolors: 1.0.0
       pretty-bytes: 5.6.0
       pretty-ms: 7.0.1
+      signal-exit: 4.0.1
       time-span: 4.0.0
     devDependencies:
       '@types/node-fetch': 2.6.2
@@ -3323,11 +3323,6 @@ packages:
     dependencies:
       cb2promise: 1.1.1
     dev: true
-
-  /exit-hook/2.2.1:
-    resolution: {integrity: sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==}
-    engines: {node: '>=6'}
-    dev: false
 
   /exit/0.1.2:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
@@ -6998,6 +6993,11 @@ packages:
 
   /signal-exit/3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  /signal-exit/4.0.1:
+    resolution: {integrity: sha512-uUWsN4aOxJAS8KOuf3QMyFtgm1pkb6I+KRZbRF/ghdf5T7sM+B1lLLzPDxswUjkmHyxQAVzEgG35E3NzDM9GVw==}
+    engines: {node: '>=14'}
+    dev: false
 
   /simple-git-hooks/2.8.1:
     resolution: {integrity: sha512-DYpcVR1AGtSfFUNzlBdHrQGPsOhuuEJ/FkmPOOlFysP60AHd3nsEpkGq/QEOdtUyT1Qhk7w9oLmFoMG+75BDog==}


### PR DESCRIPTION
- use `signal-exit` instead of `exit-hook` (it's tinier).
- fix getting started example showcasing how to interact with Edge Runtime via local server. 
- prefer `example.vercel.sh` over `example.com`

closes #319