### PR TITLE
use node's webcrypto when available

### DIFF
--- a/.changeset/cold-geckos-serve.md
+++ b/.changeset/cold-geckos-serve.md
@@ -1,0 +1,5 @@
+---
+'@edge-runtime/primitives': minor
+---
+
+use node's webcrypto when available

--- a/packages/primitives/src/primitives/index.js
+++ b/packages/primitives/src/primitives/index.js
@@ -105,37 +105,6 @@ function load() {
   })
 
   if (typeof SubtleCrypto !== 'undefined') {
-    // @ts-ignore
-    const { value: _generateKey } = Object.getOwnPropertyDescriptor(SubtleCrypto.prototype, 'generateKey');
-    // @ts-ignore
-    const { value: _importKey } = Object.getOwnPropertyDescriptor(SubtleCrypto.prototype, 'importKey');
-
-    Object.defineProperties(SubtleCrypto.prototype, {
-      generateKey: {
-        value: function generateKey () {
-          return _generateKey.apply(this, arguments).then((/** @type {CryptoKey | CryptoKeyPair} */result) => {
-            if (result instanceof CryptoKey) {
-              return result;
-            }
-            if (result.publicKey.algorithm.name === 'Ed448' || result.publicKey.algorithm.name === 'X448') {
-              throw new DOMException('Unrecognized algorithm name', 'NotSupportedError')
-            }
-            return result
-          })
-        },
-      },
-      importKey: {
-        value: function importKey () {
-          return _importKey.apply(this, arguments).then((/** @type {CryptoKey} */ result) => {
-            if (result.algorithm.name === 'Ed448' || result.algorithm.name === 'X448') {
-              throw new DOMException('Unrecognized algorithm name', 'NotSupportedError')
-            }
-            return result
-          })
-        },
-      },
-    })
-
     Object.assign(context, {
       crypto: globalThis.crypto,
       Crypto: globalThis.Crypto,

--- a/packages/primitives/src/primitives/index.js
+++ b/packages/primitives/src/primitives/index.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 const path = require('path')
+const nodeCrypto = require('crypto')
 
 function load() {
   /** @type {Record<string, any>} */
@@ -110,6 +111,18 @@ function load() {
       Crypto: globalThis.Crypto,
       CryptoKey: globalThis.CryptoKey,
       SubtleCrypto: globalThis.SubtleCrypto,
+    })
+  // @ts-ignore
+  } else if (nodeCrypto.webcrypto) {
+    Object.assign(context, {
+      // @ts-ignore
+      crypto: nodeCrypto.webcrypto,
+      // @ts-ignore
+      Crypto: nodeCrypto.webcrypto.constructor,
+      // @ts-ignore
+      CryptoKey: nodeCrypto.webcrypto.CryptoKey,
+      // @ts-ignore
+      SubtleCrypto: nodeCrypto.webcrypto.subtle.constructor,
     })
   } else {
     const cryptoImpl = require('./crypto')

--- a/packages/vm/tests/integration/crypto.test.ts
+++ b/packages/vm/tests/integration/crypto.test.ts
@@ -40,3 +40,30 @@ function toHex(buffer: ArrayBuffer) {
     .map((b) => b.toString(16).padStart(2, '0'))
     .join('')
 }
+
+const nodeWebCrypto = typeof SubtleCrypto !== 'undefined'
+if (nodeWebCrypto) {
+  test('Ed25519', async () => {
+    const vm = new EdgeVM()
+
+    function fn() {
+      return crypto.subtle.generateKey('Ed25519', false, ['sign', 'verify'])
+    }
+
+    const kp = await vm.evaluate(`(${fn})()`)
+    expect(kp).toHaveProperty('privateKey')
+    expect(kp).toHaveProperty('publicKey')
+  })
+
+  test('X25519', async () => {
+    const vm = new EdgeVM()
+
+    function fn() {
+      return crypto.subtle.generateKey('X25519', false, ['deriveBits', 'deriveKey'])
+    }
+
+    const kp = await vm.evaluate(`(${fn})()`)
+    expect(kp).toHaveProperty('privateKey')
+    expect(kp).toHaveProperty('publicKey')
+  })
+}

--- a/packages/vm/tests/integration/crypto.test.ts
+++ b/packages/vm/tests/integration/crypto.test.ts
@@ -41,8 +41,8 @@ function toHex(buffer: ArrayBuffer) {
     .join('')
 }
 
-const nodeWebCrypto = typeof SubtleCrypto !== 'undefined'
-if (nodeWebCrypto) {
+const nodeMajorVersion = parseInt(process.versions.node.split('.')[0])
+if (nodeMajorVersion >= 16) {
   test('Ed25519', async () => {
     const vm = new EdgeVM()
 


### PR DESCRIPTION
This change makes it so that if the node process has a webcrypto API implementation that this implementation be used instead of `@peculiar/webcrypto` so that Ed25519 and X25519 algorithms become available.

~It also patches out the use of Ed448 and X448 Algorithms which are not present in Edge Functions at Vercel. Ed25519 and X25519 already is (or should be?) since it's already present in workerd and CF Workers. This prototype update can easily be omitted but then EdgeRuntime would support more than the Edge Functions at Vercel runtime... This way they're aligned, but it's ugly and messes with the prototype when using edge runtime programatically... I'm happy to remove it from the PR~

The @peculiar/webcrypto dependency can be safely dropped when node 14 support is removed.