### PR TITLE
Add "react-server" export condition to Jest environment

### DIFF
--- a/.changeset/beige-lions-film.md
+++ b/.changeset/beige-lions-film.md
@@ -1,0 +1,5 @@
+---
+"@edge-runtime/jest-environment": patch
+---
+
+Add "react-server" export condition to Jest environment

--- a/packages/jest-environment/src/index.ts
+++ b/packages/jest-environment/src/index.ts
@@ -68,7 +68,7 @@ export = class EdgeEnvironment implements JestEnvironment<number> {
   }
 
   exportConditions(): string[] {
-    return ['edge', 'edge-light']
+    return ['edge', 'edge-light', 'react-server']
   }
 
   getVmContext(): Context | null {


### PR DESCRIPTION
This should make it so that if you import the 'server-only' poison pill module, it does not throw an error, because the module resolver will interpret it as a server module instead of a client one.