### PR TITLE
remove dynamism in imports

### DIFF
--- a/.changeset/serious-moons-remain.md
+++ b/.changeset/serious-moons-remain.md
@@ -1,0 +1,8 @@
+---
+'@edge-runtime/primitives': patch
+---
+
+remove dynamism in imports: add a `${primitive}.text.js` file that will be
+required, instead of using `fs` to read the file at runtime.
+
+This will help bundlers to statically analyze the code.

--- a/packages/primitives/scripts/build.ts
+++ b/packages/primitives/scripts/build.ts
@@ -142,6 +142,35 @@ async function bundlePackage() {
     ],
   })
 
+  if (true) {
+    const loadSource = fs.promises.readFile(
+      resolve(__dirname, '../dist/load.js'),
+      'utf8'
+    )
+    const files = new Set<string>()
+    const loadSourceWithPolyfills = (await loadSource).replace(
+      /injectSourceCode\("(.+)"\)/g,
+      (_, filename) => {
+        files.add(filename)
+        return `require(${JSON.stringify(`${filename}.text.js`)})`
+      }
+    )
+    await fs.promises.writeFile(
+      resolve(__dirname, '../dist/load.js'),
+      loadSourceWithPolyfills
+    )
+    for (const file of files) {
+      const contents = await fs.promises.readFile(
+        resolve(__dirname, '../dist', file),
+        'utf8'
+      )
+      await fs.promises.writeFile(
+        resolve(__dirname, '../dist', `${file}.text.js`),
+        `module.exports = ${JSON.stringify(contents)}`
+      )
+    }
+  }
+
   for (const file of filesExt.map((file) => parse(file).name)) {
     if (file !== 'index') {
       await fs.promises.mkdir(resolve(__dirname, `../${file}`)).catch(() => {})

--- a/packages/primitives/src/injectSourceCode.d.ts
+++ b/packages/primitives/src/injectSourceCode.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Injects the source code of a file into a string.
+ * This relies on the build script to generate a file with the same name as the
+ * file to be injected, but with a `.text.js` extension.
+ */
+declare const injectSourceCode: (path: string) => string


### PR DESCRIPTION
this PR removes the required (explicit) file system read in favor of static `require` calls,
which is practically an implicit file system read, but statically analyzable by bundlers.
