### PR TITLE
remove javascript files in favor of only having the text imports

### DIFF
--- a/.changeset/violet-birds-study.md
+++ b/.changeset/violet-birds-study.md
@@ -1,0 +1,5 @@
+---
+'@edge-runtime/primitives': major
+---
+
+remove specific-polyfill entrypoints

--- a/packages/primitives/.gitignore
+++ b/packages/primitives/.gitignore
@@ -1,11 +1,2 @@
-abort-controller
-blob
-console
-crypto
-encoding
-events
-fetch
-streams
-structured-clone
-url
 types
+load

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -45,20 +45,9 @@
     "node": ">=14"
   },
   "files": [
-    "abort-controller",
-    "blob",
-    "console",
-    "crypto",
     "dist",
-    "encoding",
-    "events",
-    "fetch",
     "load",
-    "streams",
-    "structured-clone",
-    "text-encoding-streams",
-    "types",
-    "url"
+    "types"
   ],
   "scripts": {
     "build": "ts-node scripts/build.ts",

--- a/packages/primitives/scripts/build.ts
+++ b/packages/primitives/scripts/build.ts
@@ -122,36 +122,9 @@ async function bundlePackage() {
     ],
   })
 
-  if (true) {
-    const loadSource = fs.promises.readFile(
-      resolve(__dirname, '../dist/load.js'),
-      'utf8'
-    )
-    const files = new Set<string>()
-    const loadSourceWithPolyfills = (await loadSource).replace(
-      /injectSourceCode\("(.+)"\)/g,
-      (_, filename) => {
-        files.add(filename)
-        return `require(${JSON.stringify(`${filename}.text.js`)})`
-      }
-    )
-    await fs.promises.writeFile(
-      resolve(__dirname, '../dist/load.js'),
-      loadSourceWithPolyfills
-    )
-    for (const file of files) {
-      const contents = await fs.promises.readFile(
-        resolve(__dirname, '../dist', file),
-        'utf8'
-      )
-      await fs.promises.writeFile(
-        resolve(__dirname, '../dist', `${file}.text.js`),
-        `module.exports = ${JSON.stringify(contents)}`
-      )
-    }
-  }
+  await generateTextFiles()
 
-  for (const file of filesExt.map((file) => parse(file).name)) {
+  for (const file of ['load']) {
     if (file !== 'index') {
       await fs.promises.mkdir(resolve(__dirname, `../${file}`)).catch(() => {})
       await fs.promises.writeFile(
@@ -166,6 +139,37 @@ async function bundlePackage() {
         )
       )
     }
+  }
+}
+
+async function generateTextFiles() {
+  const loadSource = fs.promises.readFile(
+    resolve(__dirname, '../dist/load.js'),
+    'utf8'
+  )
+  const files = new Set<string>()
+  const loadSourceWithPolyfills = (await loadSource).replace(
+    /injectSourceCode\("(.+)"\)/g,
+    (_, filename) => {
+      files.add(filename)
+      return `require(${JSON.stringify(`${filename}.text.js`)})`
+    }
+  )
+  await fs.promises.writeFile(
+    resolve(__dirname, '../dist/load.js'),
+    loadSourceWithPolyfills
+  )
+  for (const file of files) {
+    const contents = await fs.promises.readFile(
+      resolve(__dirname, '../dist', file),
+      'utf8'
+    )
+    await fs.promises.writeFile(
+      resolve(__dirname, '../dist', `${file}.text.js`),
+      `module.exports = ${JSON.stringify(contents)}`
+    )
+    // remove the original file
+    await fs.promises.unlink(resolve(__dirname, '../dist', file))
   }
 }
 


### PR DESCRIPTION
in one of the latest PRs we introduced `file.js.text.js` which contains the entire generated module, serialized as a string, to avoid `fs` usage.
this PR removes the original `file.js` files as they are not needed. This is a breaking change because now people won't be able to import specific packages like `@edge-runtime/primitives/crypto` but I don't think this is an issue as this would break anyway as there's a certain order to these imports. The better way is to import the ponyfill.
