### PR TITLE
chore(repl): add history

### DIFF
--- a/.changeset/thirty-goats-complain.md
+++ b/.changeset/thirty-goats-complain.md
@@ -1,0 +1,5 @@
+---
+"edge-runtime": patch
+---
+
+chore(repl): add history

--- a/packages/runtime/src/cli/repl.ts
+++ b/packages/runtime/src/cli/repl.ts
@@ -1,5 +1,7 @@
 import { createFormat } from '@edge-runtime/format'
 import createRepl from 'repl'
+import { homedir } from 'os'
+import { join } from 'path'
 
 import { EdgeRuntime } from '../edge-runtime'
 
@@ -10,6 +12,7 @@ const writer: createRepl.REPLWriter = (output) => {
 }
 
 const repl = createRepl.start({ prompt: 'ƒ => ', writer })
+repl.setupHistory(join(homedir(), '.edge_runtime_repl_history'), () => {})
 
 Object.getOwnPropertyNames(repl.context).forEach(
   (mod) => delete repl.context[mod]


### PR DESCRIPTION
So next time you open a REPL session, your previous commands are there:

![CleanShot 2023-06-01 at 12 54 30](https://github.com/vercel/edge-runtime/assets/2096101/32fd8b26-6165-443a-be37-029d6265e515)
