### PR TITLE
Fixed Cookie Parsing

### DIFF
--- a/.changeset/swift-berries-argue.md
+++ b/.changeset/swift-berries-argue.md
@@ -1,0 +1,5 @@
+---
+"@edge-runtime/cookies": patch
+---
+
+Fixed Cookie Parsing

--- a/packages/cookies/src/serialize.ts
+++ b/packages/cookies/src/serialize.ts
@@ -23,9 +23,7 @@ export function serialize(c: ResponseCookie | RequestCookie): string {
 export function parseCookieString(cookie: string) {
   const map = new Map<string, string>()
 
-  const pairs = cookie.split(/; */)
-  for (let i = 0; i < pairs.length; i++) {
-    const pair = pairs[i]
+  for (const pair of cookie.split(/; */)) {
     if (!pair) continue
 
     const splitAt = pair.indexOf('=')

--- a/packages/cookies/src/serialize.ts
+++ b/packages/cookies/src/serialize.ts
@@ -38,9 +38,7 @@ export function parseCookieString(cookie: string) {
     // value.
     const [key, value] = [pair.slice(0, splitAt), pair.slice(splitAt + 1)]
     try {
-      // Decode the value using the `decodeURIComponent` function and trim
-      // whitespace from it.
-      map.set(key, decodeURIComponent(value.trim() ?? 'true'))
+      map.set(key, decodeURIComponent(value ?? 'true'))
     } catch {
       // ignore invalid encoded values
     }

--- a/packages/cookies/src/serialize.ts
+++ b/packages/cookies/src/serialize.ts
@@ -23,12 +23,26 @@ export function serialize(c: ResponseCookie | RequestCookie): string {
 export function parseCookieString(cookie: string) {
   const map = new Map<string, string>()
 
-  for (const pair of cookie.split(/; */)) {
+  const pairs = cookie.split(/; */)
+  for (let i = 0; i < pairs.length; i++) {
+    const pair = pairs[i]
     if (!pair) continue
+
     const splitAt = pair.indexOf('=')
+
+    // If the attribute doesn't have a value, set it to 'true'.
+    if (splitAt === -1) {
+      map.set(pair, 'true')
+      continue
+    }
+
+    // Otherwise split it into key and value and trim the whitespace on the
+    // value.
     const [key, value] = [pair.slice(0, splitAt), pair.slice(splitAt + 1)]
     try {
-      map.set(key, decodeURIComponent(value ?? 'true'))
+      // Decode the value using the `decodeURIComponent` function and trim
+      // whitespace from it.
+      map.set(key, decodeURIComponent(value.trim() ?? 'true'))
     } catch {
       // ignore invalid encoded values
     }


### PR DESCRIPTION
Perviously, cookies with attributes were not parsed correctly, namely:

```
Set-Cookie: my_value=true; Secure; HttpOnly
```

Did not correctly parse out the `Secure` and `HttpOnly` attributes. This addresses this by handling the edge case where there is no trailing `=` character after the attribute name (like for `HttpOnly` and `Secure`).