### PR TITLE
chore(cookies): exposes `.splitCookiesString`

### DIFF
--- a/.changeset/calm-paws-sip.md
+++ b/.changeset/calm-paws-sip.md
@@ -1,0 +1,10 @@
+---
+"@edge-runtime/cookies": patch
+"@edge-runtime/node-utils": patch
+"@edge-runtime/primitives": patch
+"@edge-runtime/types": patch
+"@edge-runtime/user-agent": patch
+"@edge-runtime/docs": patch
+---
+
+chore(cookies): expose `.splitCookiesString`

--- a/docs/pages/packages/cookies.mdx
+++ b/docs/pages/packages/cookies.mdx
@@ -78,7 +78,7 @@ function handleRequest(req: Request) {
   cookies.set('cookie-name', 'cookie-value', { maxAge: 1000 }) // make cookie persistent for 1000 seconds
   cookies.delete('old-cookie')
 
-  return new Response('', {
+  return new Response(null, {
     headers: {
       'set-cookie': headers.getAll?.('set-cookie'),
     },

--- a/docs/pages/packages/cookies.mdx
+++ b/docs/pages/packages/cookies.mdx
@@ -11,10 +11,22 @@ The main difference is that the methods are not asynchronous so they do not retu
 
 ## Installation
 
-<Tabs items={['npm', 'yarn', 'pnpm']} storageKey='selected-pkg-manager'>
-  <Tab>```sh npm install @edge-runtime/cookies --save ```</Tab>
-  <Tab>```sh yarn add @edge-runtime/cookies ```</Tab>
-  <Tab>```sh pnpm install @edge-runtime/cookies --save ```</Tab>
+<Tabs items={['npm', 'yarn', 'pnpm']} storageKey="selected-pkg-manager">
+  <Tab>
+    ```sh
+    npm install @edge-runtime/cookies --save
+    ```
+  </Tab>
+  <Tab>
+    ```sh
+    yarn add @edge-runtime/cookies
+    ```
+  </Tab>
+  <Tab>
+    ```sh
+    pnpm install @edge-runtime/cookies --save
+    ```
+  </Tab>
 </Tabs>
 
 ## Usage

--- a/docs/pages/packages/cookies.mdx
+++ b/docs/pages/packages/cookies.mdx
@@ -11,22 +11,10 @@ The main difference is that the methods are not asynchronous so they do not retu
 
 ## Installation
 
-<Tabs items={['npm', 'yarn', 'pnpm']} storageKey="selected-pkg-manager">
-  <Tab>
-    ```sh
-    npm install @edge-runtime/cookies --save
-    ```
-  </Tab>
-  <Tab>
-    ```sh
-    yarn add @edge-runtime/cookies
-    ```
-  </Tab>
-  <Tab>
-    ```sh
-    pnpm install @edge-runtime/cookies --save
-    ```
-  </Tab>
+<Tabs items={['npm', 'yarn', 'pnpm']} storageKey='selected-pkg-manager'>
+  <Tab>```sh npm install @edge-runtime/cookies --save ```</Tab>
+  <Tab>```sh yarn add @edge-runtime/cookies ```</Tab>
+  <Tab>```sh pnpm install @edge-runtime/cookies --save ```</Tab>
 </Tabs>
 
 ## Usage
@@ -72,18 +60,19 @@ use the exported `ResponseCookies` constructor:
 import { ResponseCookies } from '@edge-runtime/cookies'
 
 function handleRequest(req: Request) {
-  // do something
-  const cookies = new ResponseCookies(new Headers())
+  const headers = new Headers()
+
+  const cookies = new ResponseCookies()
   cookies.set('cookie-name', 'cookie-value', { maxAge: 1000 }) // make cookie persistent for 1000 seconds
   cookies.delete('old-cookie')
-  return response
+
+  return new Response('', {
+    headers: {
+      'set-cookie': headers.getAll?.('set-cookie'),
+    },
+  })
 }
 ```
-
-Notes:
-
-- All mutations are performed in-place and will update the `Set-Cookie` headers
-  in the provided `Response` object.
 
 #### Available methods
 

--- a/packages/cookies/src/index.ts
+++ b/packages/cookies/src/index.ts
@@ -1,3 +1,4 @@
 export type { CookieListItem, RequestCookie, ResponseCookie } from './types'
 export { RequestCookies } from './request-cookies'
 export { ResponseCookies } from './response-cookies'
+export { splitCookiesString } from './serialize'

--- a/packages/cookies/src/request-cookies.ts
+++ b/packages/cookies/src/request-cookies.ts
@@ -1,5 +1,5 @@
 import type { RequestCookie } from './types'
-import { parseCookieString, serialize } from './serialize'
+import { parseCookie, stringifyCookie } from './serialize'
 
 /**
  * A class for manipulating {@link Request} cookies (`Cookie` header).
@@ -14,7 +14,7 @@ export class RequestCookies {
     this._headers = requestHeaders
     const header = requestHeaders.get('cookie')
     if (header) {
-      const parsed = parseCookieString(header)
+      const parsed = parseCookie(header)
       for (const [name, value] of parsed) {
         this._parsed.set(name, { name, value })
       }
@@ -61,8 +61,8 @@ export class RequestCookies {
     this._headers.set(
       'cookie',
       Array.from(map)
-        .map(([_, value]) => serialize(value))
-        .join('; ')
+        .map(([_, value]) => stringifyCookie(value))
+        .join('; '),
     )
     return this
   }
@@ -72,7 +72,7 @@ export class RequestCookies {
    */
   delete(
     /** Name or names of the cookies to be deleted  */
-    names: string | string[]
+    names: string | string[],
   ): boolean | boolean[] {
     const map = this._parsed
     const result = !Array.isArray(names)
@@ -81,8 +81,8 @@ export class RequestCookies {
     this._headers.set(
       'cookie',
       Array.from(map)
-        .map(([_, value]) => serialize(value))
-        .join('; ')
+        .map(([_, value]) => stringifyCookie(value))
+        .join('; '),
     )
     return result
   }

--- a/packages/cookies/src/response-cookies.ts
+++ b/packages/cookies/src/response-cookies.ts
@@ -1,5 +1,9 @@
 import type { ResponseCookie } from './types'
-import { parseSetCookieString, serialize } from './serialize'
+import {
+  splitCookiesString,
+  parseSetCookie,
+  stringifyCookie,
+} from './serialize'
 
 /**
  * A class for manipulating {@link Response} cookies (`Set-Cookie` header).
@@ -26,7 +30,7 @@ export class ResponseCookies {
       : splitCookiesString(setCookie)
 
     for (const cookieString of cookieStrings) {
-      const parsed = parseSetCookieString(cookieString)
+      const parsed = parseSetCookie(cookieString)
       if (parsed) this._parsed.set(parsed.name, parsed)
     }
   }
@@ -85,14 +89,14 @@ export class ResponseCookies {
   }
 
   toString() {
-    return [...this._parsed.values()].map(serialize).join('; ')
+    return [...this._parsed.values()].map(stringifyCookie).join('; ')
   }
 }
 
 function replace(bag: Map<string, ResponseCookie>, headers: Headers) {
   headers.delete('set-cookie')
   for (const [, value] of bag) {
-    const serialized = serialize(value)
+    const serialized = stringifyCookie(value)
     headers.append('set-cookie', serialized)
   }
 }
@@ -111,83 +115,4 @@ function normalizeCookie(cookie: ResponseCookie = { name: '', value: '' }) {
   }
 
   return cookie
-}
-
-/**
- * @source https://github.com/nfriedly/set-cookie-parser/blob/master/lib/set-cookie.js
- *
- * Set-Cookie header field-values are sometimes comma joined in one string. This splits them without choking on commas
- * that are within a single set-cookie field-value, such as in the Expires portion.
- * This is uncommon, but explicitly allowed - see https://tools.ietf.org/html/rfc2616#section-4.2
- * Node.js does this for every header *except* set-cookie - see https://github.com/nodejs/node/blob/d5e363b77ebaf1caf67cd7528224b651c86815c1/lib/_http_incoming.js#L128
- * React Native's fetch does this for *every* header, including set-cookie.
- *
- * Based on: https://github.com/google/j2objc/commit/16820fdbc8f76ca0c33472810ce0cb03d20efe25
- * Credits to: https://github.com/tomball for original and https://github.com/chrusart for JavaScript implementation
- */
-function splitCookiesString(cookiesString: string) {
-  if (!cookiesString) return []
-  var cookiesStrings = []
-  var pos = 0
-  var start
-  var ch
-  var lastComma
-  var nextStart
-  var cookiesSeparatorFound
-
-  function skipWhitespace() {
-    while (pos < cookiesString.length && /\s/.test(cookiesString.charAt(pos))) {
-      pos += 1
-    }
-    return pos < cookiesString.length
-  }
-
-  function notSpecialChar() {
-    ch = cookiesString.charAt(pos)
-
-    return ch !== '=' && ch !== ';' && ch !== ','
-  }
-
-  while (pos < cookiesString.length) {
-    start = pos
-    cookiesSeparatorFound = false
-
-    while (skipWhitespace()) {
-      ch = cookiesString.charAt(pos)
-      if (ch === ',') {
-        // ',' is a cookie separator if we have later first '=', not ';' or ','
-        lastComma = pos
-        pos += 1
-
-        skipWhitespace()
-        nextStart = pos
-
-        while (pos < cookiesString.length && notSpecialChar()) {
-          pos += 1
-        }
-
-        // currently special character
-        if (pos < cookiesString.length && cookiesString.charAt(pos) === '=') {
-          // we found cookies separator
-          cookiesSeparatorFound = true
-          // pos is inside the next cookie, so back up and return it.
-          pos = nextStart
-          cookiesStrings.push(cookiesString.substring(start, lastComma))
-          start = pos
-        } else {
-          // in param ',' or param separator ';',
-          // we continue from that comma
-          pos = lastComma + 1
-        }
-      } else {
-        pos += 1
-      }
-    }
-
-    if (!cookiesSeparatorFound || pos >= cookiesString.length) {
-      cookiesStrings.push(cookiesString.substring(start, cookiesString.length))
-    }
-  }
-
-  return cookiesStrings
 }

--- a/packages/cookies/src/serialize.ts
+++ b/packages/cookies/src/serialize.ts
@@ -1,6 +1,6 @@
 import type { RequestCookie, ResponseCookie } from './types'
 
-export function serialize(c: ResponseCookie | RequestCookie): string {
+export function stringifyCookie(c: ResponseCookie | RequestCookie): string {
   const attrs = [
     'path' in c && c.path && `Path=${c.path}`,
     'expires' in c &&
@@ -20,7 +20,7 @@ export function serialize(c: ResponseCookie | RequestCookie): string {
 }
 
 /** Parse a `Cookie` header value */
-export function parseCookieString(cookie: string) {
+export function parseCookie(cookie: string) {
   const map = new Map<string, string>()
 
   for (const pair of cookie.split(/; */)) {
@@ -48,17 +48,15 @@ export function parseCookieString(cookie: string) {
 }
 
 /** Parse a `Set-Cookie` header value */
-export function parseSetCookieString(
-  setCookie: string
-): undefined | ResponseCookie {
+export function parseSetCookie(setCookie: string): undefined | ResponseCookie {
   if (!setCookie) {
     return undefined
   }
 
-  const [[name, value], ...attributes] = parseCookieString(setCookie)
+  const [[name, value], ...attributes] = parseCookie(setCookie)
   const { domain, expires, httponly, maxage, path, samesite, secure } =
     Object.fromEntries(
-      attributes.map(([key, value]) => [key.toLowerCase(), value])
+      attributes.map(([key, value]) => [key.toLowerCase(), value]),
     )
   const cookie: ResponseCookie = {
     name,
@@ -86,9 +84,89 @@ function compact<T>(t: T): T {
 }
 
 const SAME_SITE: ResponseCookie['sameSite'][] = ['strict', 'lax', 'none']
+
 function parseSameSite(string: string): ResponseCookie['sameSite'] {
   string = string.toLowerCase()
   return SAME_SITE.includes(string as any)
     ? (string as ResponseCookie['sameSite'])
     : undefined
+}
+
+/**
+ * @source https://github.com/nfriedly/set-cookie-parser/blob/master/lib/set-cookie.js
+ *
+ * Set-Cookie header field-values are sometimes comma joined in one string. This splits them without choking on commas
+ * that are within a single set-cookie field-value, such as in the Expires portion.
+ * This is uncommon, but explicitly allowed - see https://tools.ietf.org/html/rfc2616#section-4.2
+ * Node.js does this for every header *except* set-cookie - see https://github.com/nodejs/node/blob/d5e363b77ebaf1caf67cd7528224b651c86815c1/lib/_http_incoming.js#L128
+ * React Native's fetch does this for *every* header, including set-cookie.
+ *
+ * Based on: https://github.com/google/j2objc/commit/16820fdbc8f76ca0c33472810ce0cb03d20efe25
+ * Credits to: https://github.com/tomball for original and https://github.com/chrusart for JavaScript implementation
+ */
+export function splitCookiesString(cookiesString: string) {
+  if (!cookiesString) return []
+  var cookiesStrings = []
+  var pos = 0
+  var start
+  var ch
+  var lastComma
+  var nextStart
+  var cookiesSeparatorFound
+
+  function skipWhitespace() {
+    while (pos < cookiesString.length && /\s/.test(cookiesString.charAt(pos))) {
+      pos += 1
+    }
+    return pos < cookiesString.length
+  }
+
+  function notSpecialChar() {
+    ch = cookiesString.charAt(pos)
+
+    return ch !== '=' && ch !== ';' && ch !== ','
+  }
+
+  while (pos < cookiesString.length) {
+    start = pos
+    cookiesSeparatorFound = false
+
+    while (skipWhitespace()) {
+      ch = cookiesString.charAt(pos)
+      if (ch === ',') {
+        // ',' is a cookie separator if we have later first '=', not ';' or ','
+        lastComma = pos
+        pos += 1
+
+        skipWhitespace()
+        nextStart = pos
+
+        while (pos < cookiesString.length && notSpecialChar()) {
+          pos += 1
+        }
+
+        // currently special character
+        if (pos < cookiesString.length && cookiesString.charAt(pos) === '=') {
+          // we found cookies separator
+          cookiesSeparatorFound = true
+          // pos is inside the next cookie, so back up and return it.
+          pos = nextStart
+          cookiesStrings.push(cookiesString.substring(start, lastComma))
+          start = pos
+        } else {
+          // in param ',' or param separator ';',
+          // we continue from that comma
+          pos = lastComma + 1
+        }
+      } else {
+        pos += 1
+      }
+    }
+
+    if (!cookiesSeparatorFound || pos >= cookiesString.length) {
+      cookiesStrings.push(cookiesString.substring(start, cookiesString.length))
+    }
+  }
+
+  return cookiesStrings
 }

--- a/packages/cookies/test/request-cookies.test.ts
+++ b/packages/cookies/test/request-cookies.test.ts
@@ -1,6 +1,6 @@
 import { RequestCookies } from '../src/request-cookies'
 import { createFormat } from '@edge-runtime/format'
-import { parseCookieString } from '../src/serialize'
+import { parseCookie } from '../src/serialize'
 
 describe('input parsing', () => {
   test('empty cookie header element', () => {
@@ -83,7 +83,7 @@ test('formatting with @edge-runtime/format', () => {
   const format = createFormat()
   const result = format(cookies)
   expect(result).toMatchInlineSnapshot(
-    `"RequestCookies {"a":{"name":"a","value":"1"},"b":{"name":"b","value":"2"}}"`
+    `"RequestCookies {"a":{"name":"a","value":"1"},"b":{"name":"b","value":"2"}}"`,
   )
 })
 
@@ -102,12 +102,12 @@ function mapToCookieString(map: Map<string, string>) {
 describe('parse cookie string', () => {
   it('with a plain value', async () => {
     const input = new Map([['foo', 'bar']])
-    const result = parseCookieString(mapToCookieString(input))
+    const result = parseCookie(mapToCookieString(input))
     expect(result).toEqual(input)
   })
   it('with multiple `=`', async () => {
     const input = new Map([['foo', 'bar=']])
-    const result = parseCookieString(mapToCookieString(input))
+    const result = parseCookie(mapToCookieString(input))
     expect(result).toEqual(input)
   })
   it('with multiple plain values', async () => {
@@ -115,7 +115,7 @@ describe('parse cookie string', () => {
       ['foo', 'bar'],
       ['baz', 'qux'],
     ])
-    const result = parseCookieString(mapToCookieString(input))
+    const result = parseCookie(mapToCookieString(input))
     expect(result).toEqual(input)
   })
   it('with multiple values with `=`', async () => {
@@ -123,7 +123,7 @@ describe('parse cookie string', () => {
       ['foo', 'bar=='],
       ['baz', '=qux'],
     ])
-    const result = parseCookieString(mapToCookieString(input))
+    const result = parseCookie(mapToCookieString(input))
     expect(result).toEqual(input)
   })
 })

--- a/packages/cookies/test/serialize.test.ts
+++ b/packages/cookies/test/serialize.test.ts
@@ -1,0 +1,11 @@
+import { splitCookiesString } from '../src/serialize'
+
+test('.splitCookiesString', async () => {
+  const cookieString =
+    'cookie1=value1, cookie2=value2; Max-Age=1000, cookie3=value3; Domain=<domain-value>; Secure'
+  expect(splitCookiesString(cookieString)).toEqual([
+    'cookie1=value1',
+    'cookie2=value2; Max-Age=1000',
+    'cookie3=value3; Domain=<domain-value>; Secure',
+  ])
+})

--- a/packages/node-utils/package.json
+++ b/packages/node-utils/package.json
@@ -23,6 +23,9 @@
     "utils",
     "web"
   ],
+  "dependencies": {
+    "@edge-runtime/cookies": "workspace:*"
+  },
   "devDependencies": {
     "@edge-runtime/primitives": "workspace:3.0.3",
     "@types/test-listen": "1.1.0",

--- a/packages/node-utils/package.json
+++ b/packages/node-utils/package.json
@@ -27,7 +27,7 @@
     "@edge-runtime/cookies": "workspace:*"
   },
   "devDependencies": {
-    "@edge-runtime/primitives": "workspace:3.0.3",
+    "@edge-runtime/primitives": "workspace:*",
     "@types/test-listen": "1.1.0",
     "test-listen": "1.1.0",
     "tsup": "7"

--- a/packages/node-utils/src/edge-to-node/headers.ts
+++ b/packages/node-utils/src/edge-to-node/headers.ts
@@ -1,8 +1,9 @@
 import type { Headers } from '@edge-runtime/primitives'
 import type { OutgoingHttpHeaders, ServerResponse } from 'node:http'
+import { splitCookiesString } from '@edge-runtime/cookies'
 
 export function toOutgoingHeaders(
-  headers?: Headers & { raw?: () => Record<string, string> }
+  headers?: Headers & { raw?: () => Record<string, string> },
 ): OutgoingHttpHeaders {
   const outputHeaders: OutgoingHttpHeaders = {}
   if (headers) {
@@ -21,87 +22,11 @@ export function toOutgoingHeaders(
 
 export function mergeIntoServerResponse(
   headers: OutgoingHttpHeaders,
-  serverResponse: ServerResponse
+  serverResponse: ServerResponse,
 ) {
   for (const [name, value] of Object.entries(headers)) {
     if (value !== undefined) {
       serverResponse.setHeader(name, value)
     }
   }
-}
-
-/*
-  Set-Cookie header field-values are sometimes comma joined in one string. This splits them without choking on commas
-  that are within a single set-cookie field-value, such as in the Expires portion.
-  This is uncommon, but explicitly allowed - see https://tools.ietf.org/html/rfc2616#section-4.2
-  Node.js does this for every header *except* set-cookie - see https://github.com/nodejs/node/blob/d5e363b77ebaf1caf67cd7528224b651c86815c1/lib/_http_incoming.js#L128
-  React Native's fetch does this for *every* header, including set-cookie.
-  
-  Based on: https://github.com/google/j2objc/commit/16820fdbc8f76ca0c33472810ce0cb03d20efe25
-  Credits to: https://github.com/tomball for original and https://github.com/chrusart for JavaScript implementation
-*/
-function splitCookiesString(cookiesString: string) {
-  var cookiesStrings = []
-  var pos = 0
-  var start
-  var ch
-  var lastComma
-  var nextStart
-  var cookiesSeparatorFound
-
-  function skipWhitespace() {
-    while (pos < cookiesString.length && /\s/.test(cookiesString.charAt(pos))) {
-      pos += 1
-    }
-    return pos < cookiesString.length
-  }
-
-  function notSpecialChar() {
-    ch = cookiesString.charAt(pos)
-
-    return ch !== '=' && ch !== ';' && ch !== ','
-  }
-
-  while (pos < cookiesString.length) {
-    start = pos
-    cookiesSeparatorFound = false
-
-    while (skipWhitespace()) {
-      ch = cookiesString.charAt(pos)
-      if (ch === ',') {
-        // ',' is a cookie separator if we have later first '=', not ';' or ','
-        lastComma = pos
-        pos += 1
-
-        skipWhitespace()
-        nextStart = pos
-
-        while (pos < cookiesString.length && notSpecialChar()) {
-          pos += 1
-        }
-
-        // currently special character
-        if (pos < cookiesString.length && cookiesString.charAt(pos) === '=') {
-          // we found cookies separator
-          cookiesSeparatorFound = true
-          // pos is inside the next cookie, so back up and return it.
-          pos = nextStart
-          cookiesStrings.push(cookiesString.substring(start, lastComma))
-          start = pos
-        } else {
-          // in param ',' or param separator ';',
-          // we continue from that comma
-          pos = lastComma + 1
-        }
-      } else {
-        pos += 1
-      }
-    }
-
-    if (!cookiesSeparatorFound || pos >= cookiesString.length) {
-      cookiesStrings.push(cookiesString.substring(start, cookiesString.length))
-    }
-  }
-
-  return cookiesStrings
 }

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -23,7 +23,7 @@
     "web"
   ],
   "devDependencies": {
-    "@edge-runtime/format": "workspace:2.1.0",
+    "@edge-runtime/format": "workspace:*",
     "@peculiar/webcrypto": "1.4.3",
     "@stardazed/streams-text-encoding": "1.0.2",
     "@ungap/structured-clone": "1.2.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -24,7 +24,7 @@
     "web"
   ],
   "dependencies": {
-    "@edge-runtime/primitives": "workspace:3.0.3"
+    "@edge-runtime/primitives": "workspace:*"
   },
   "engines": {
     "node": ">=14"

--- a/packages/user-agent/package.json
+++ b/packages/user-agent/package.json
@@ -25,7 +25,7 @@
     "web"
   ],
   "devDependencies": {
-    "@edge-runtime/jest-environment": "workspace:2.2.4",
+    "@edge-runtime/jest-environment": "workspace:*",
     "@types/ua-parser-js": "0.7.36",
     "tsup": "7",
     "ua-parser-js": "1.0.35"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,9 +167,13 @@ importers:
         version: link:../jest-environment
 
   packages/node-utils:
+    dependencies:
+      '@edge-runtime/cookies':
+        specifier: workspace:*
+        version: link:../cookies
     devDependencies:
       '@edge-runtime/primitives':
-        specifier: workspace:3.0.3
+        specifier: workspace:*
         version: link:../primitives
       '@types/test-listen':
         specifier: 1.1.0
@@ -205,7 +209,7 @@ importers:
   packages/primitives:
     devDependencies:
       '@edge-runtime/format':
-        specifier: workspace:2.1.0
+        specifier: workspace:*
         version: link:../format
       '@peculiar/webcrypto':
         specifier: 1.4.3
@@ -296,13 +300,13 @@ importers:
   packages/types:
     dependencies:
       '@edge-runtime/primitives':
-        specifier: workspace:3.0.3
+        specifier: workspace:*
         version: link:../primitives
 
   packages/user-agent:
     devDependencies:
       '@edge-runtime/jest-environment':
-        specifier: workspace:2.2.4
+        specifier: workspace:*
         version: link:../jest-environment
       '@types/ua-parser-js':
         specifier: 0.7.36


### PR DESCRIPTION
Also, provided a more helpful `ResponseCookies` example that clarifies response headers should be written by the user code:

```js
function handleRequest(req: Request) {
  const headers = new Headers()

  const cookies = new ResponseCookies()
  cookies.set('cookie-name', 'cookie-value', { maxAge: 1000 }) // make cookie persistent for 1000 seconds
  cookies.delete('old-cookie')

  return new Response('', {
    headers: {
      'set-cookie': headers.getAll?.('set-cookie'),
    },
  }
```