### PR TITLE
fix(cookies): add `.has` in `ResponseCookies`

### DIFF
--- a/.changeset/mighty-nails-invite.md
+++ b/.changeset/mighty-nails-invite.md
@@ -1,5 +1,5 @@
 ---
-'@edge-runtime/cookies': minor
+'@edge-runtime/cookies': fix
 ---
 
-feat(cookies): add has in response cookies
+fix(cookies): add `.has` in `ResponseCookies`

--- a/.changeset/mighty-nails-invite.md
+++ b/.changeset/mighty-nails-invite.md
@@ -1,0 +1,5 @@
+---
+'@edge-runtime/cookies': minor
+---
+
+feat(cookies): add has in response cookies

--- a/packages/cookies/src/response-cookies.ts
+++ b/packages/cookies/src/response-cookies.ts
@@ -59,6 +59,10 @@ export class ResponseCookies {
     return all.filter((c) => c.name === key)
   }
 
+  has(name: string) {
+    return this._parsed.has(name)
+  }
+
   /**
    * {@link https://wicg.github.io/cookie-store/#CookieStore-set CookieStore#set} without the Promise.
    */

--- a/packages/cookies/test/request-cookies.test.ts
+++ b/packages/cookies/test/request-cookies.test.ts
@@ -69,6 +69,13 @@ test('adding a cookie', () => {
   ])
 })
 
+test('cookies.has()', () => {
+  const headers = requestHeadersWithCookies('a=1; b=2')
+  const cookies = new RequestCookies(headers)
+  cookies.set('foo', 'bar')
+  expect(cookies.has('foo')).toBe(true)
+})
+
 test('cookies.toString()', () => {
   const headers = requestHeadersWithCookies('a=1; b=2')
   const cookies = new RequestCookies(headers)

--- a/packages/cookies/test/response-cookies.test.ts
+++ b/packages/cookies/test/response-cookies.test.ts
@@ -170,6 +170,13 @@ test('options are not modified', async () => {
   expect(options).toEqual({ maxAge: 10000 })
 })
 
+test('cookies.has()', () => {
+  const headers = new Headers()
+  const cookies = new ResponseCookies(headers)
+  cookies.set('foo', 'bar')
+  expect(cookies.has('foo')).toBe(true)
+})
+
 test('cookies.toString()', () => {
   const cookies = new ResponseCookies(new Headers())
   cookies.set({


### PR DESCRIPTION
> Since Next.js cookies function returns ResponseCookies as ReadonlyRequestCookies in server requests, cookies().has(//...) throws a TypeError .has is not a function.

Added `has` in ResponseCookies and tests.

Fixes: #532 [Next.js-#54005](https://github.com/vercel/next.js/discussions/54005)