### PR TITLE
feat(primitives): drop node14

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "typescript": "latest"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "scripts": {
     "build": "turbo run build",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "@jest/types": "29.5.0",
     "@svitejs/changesets-changelog-github-compact": "latest",
     "@types/jest": "29.5.3",
-    "@types/node": "14",
+    "@types/node": "16",
     "c8": "latest",
     "esbuild": "0.19.2",
     "finepack": "latest",

--- a/packages/cookies/package.json
+++ b/packages/cookies/package.json
@@ -31,7 +31,7 @@
     "tsup": "7"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "files": [
     "dist"

--- a/packages/format/package.json
+++ b/packages/format/package.json
@@ -27,7 +27,7 @@
     "tsup": "7"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "files": [
     "dist"

--- a/packages/integration-tests/tests/abort-controller.test.ts
+++ b/packages/integration-tests/tests/abort-controller.test.ts
@@ -46,7 +46,7 @@ describe('AbortController', () => {
     expect(controller.signal).toBeInstanceOf(AbortSignal)
     // @ts-expect-error
     expect(() => (controller.signal = 'not-supported')).toThrow(
-      /Cannot set property signal of .* which has only a getter/
+      /Cannot set property signal of .* which has only a getter/,
     )
   })
 })
@@ -56,7 +56,7 @@ describe('AbortSignal', () => {
     it('automatically aborts after some time', async () => {
       const reason = new DOMException(
         'The operation timed out.',
-        'TimeoutError'
+        'TimeoutError',
       )
       const signal = AbortSignal.timeout(100)
       const promise = runAbortedProcess({ signal })
@@ -78,7 +78,7 @@ describe('AbortSignal', () => {
     it('creates signal with no reason', async () => {
       const reason = new DOMException(
         'The operation was aborted.',
-        'AbortError'
+        'AbortError',
       )
       const signal = AbortSignal.abort()
       expect(signal.aborted).toBe(true)
@@ -93,7 +93,7 @@ describe('AbortSignal', () => {
     expect(signal.reason).toBe(reason)
     // @ts-expect-error
     expect(() => (signal.reason = 'not-supported')).toThrow(
-      /Cannot set property reason of .* which has only a getter/
+      /Cannot set property reason of .* which has only a getter/,
     )
   })
 
@@ -103,13 +103,13 @@ describe('AbortSignal', () => {
     expect(signal.aborted).toBe(aborted)
     // @ts-expect-error
     expect(() => (signal.aborted = true)).toThrow(
-      /Cannot set property aborted of .* which has only a getter/
+      /Cannot set property aborted of .* which has only a getter/,
     )
   })
 
   it('can not be created with constructor', () => {
     expect(() => new AbortSignal()).toThrow(
-      new TypeError('Illegal constructor.')
+      new TypeError('Illegal constructor.'),
     )
   })
 
@@ -121,11 +121,11 @@ describe('AbortSignal', () => {
     await new Promise((resolve) => setTimeout(resolve, 200))
     expect(signal.aborted).toBe(true)
     expect(signal.reason).toEqual(
-      new DOMException('The operation timed out.', 'TimeoutError')
+      new DOMException('The operation timed out.', 'TimeoutError'),
     )
     expect(onabort).toHaveBeenCalledTimes(1)
     expect(onabort).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'abort' })
+      expect.objectContaining({ type: 'abort' }),
     )
   })
 })

--- a/packages/jest-environment/package.json
+++ b/packages/jest-environment/package.json
@@ -30,7 +30,7 @@
     "jest-util": "29.5.0"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "files": [
     "dist"

--- a/packages/jest-expect/package.json
+++ b/packages/jest-expect/package.json
@@ -33,7 +33,7 @@
     "@edge-runtime/jest-environment": "workspace:*"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "files": [
     "dist",

--- a/packages/node-utils/package.json
+++ b/packages/node-utils/package.json
@@ -33,7 +33,7 @@
     "tsup": "7"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "files": [
     "dist"

--- a/packages/ponyfill/package.json
+++ b/packages/ponyfill/package.json
@@ -35,7 +35,7 @@
     "acorn-walk": "8.2.0"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "files": [
     "src"

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -25,7 +25,6 @@
   "devDependencies": {
     "@edge-runtime/format": "workspace:*",
     "@ungap/structured-clone": "1.2.0",
-    "aggregate-error-ponyfill": "1.1.0",
     "blob-polyfill": "7.0.20220408",
     "esbuild-plugin-alias": "latest",
     "event-target-shim": "6.0.2",

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -24,7 +24,6 @@
   ],
   "devDependencies": {
     "@edge-runtime/format": "workspace:*",
-    "@peculiar/webcrypto": "1.4.3",
     "@ungap/structured-clone": "1.2.0",
     "aggregate-error-ponyfill": "1.1.0",
     "blob-polyfill": "7.0.20220408",

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -37,8 +37,7 @@
     "test-listen": "1.1.0",
     "tsup": "7",
     "undici": "5.23.0",
-    "urlpattern-polyfill": "9.0.0",
-    "web-streams-polyfill": "4.0.0-beta.3"
+    "urlpattern-polyfill": "9.0.0"
   },
   "engines": {
     "node": ">=16"

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -41,7 +41,7 @@
     "web-streams-polyfill": "4.0.0-beta.3"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "files": [
     "dist",

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -25,7 +25,6 @@
   "devDependencies": {
     "@edge-runtime/format": "workspace:*",
     "@peculiar/webcrypto": "1.4.3",
-    "@stardazed/streams-text-encoding": "1.0.2",
     "@ungap/structured-clone": "1.2.0",
     "aggregate-error-ponyfill": "1.1.0",
     "blob-polyfill": "7.0.20220408",

--- a/packages/primitives/scripts/build.ts
+++ b/packages/primitives/scripts/build.ts
@@ -3,7 +3,7 @@ import alias from 'esbuild-plugin-alias'
 import { Options, build } from 'tsup'
 import fs from 'fs'
 
-const TARGET = 'node14.6'
+const TARGET = 'node16.8'
 
 const BUNDLE_OPTIONS: Options = {
   bundle: true,
@@ -110,12 +110,12 @@ async function bundlePackage() {
               return {
                 contents: Buffer.concat([
                   Buffer.from(
-                    `global.FinalizationRegistry = function () { return { register: function () {} } }`
+                    `global.FinalizationRegistry = function () { return { register: function () {} } }`,
                   ),
                   await fs.promises.readFile(args.path),
                 ]),
               }
-            }
+            },
           )
         },
       },
@@ -135,8 +135,8 @@ async function bundlePackage() {
             types: `../types/${file}.d.ts`,
           },
           null,
-          2
-        )
+          2,
+        ),
       )
     }
   }
@@ -145,7 +145,7 @@ async function bundlePackage() {
 async function generateTextFiles() {
   const loadSource = fs.promises.readFile(
     resolve(__dirname, '../dist/load.js'),
-    'utf8'
+    'utf8',
   )
   const files = new Set<string>()
   const loadSourceWithPolyfills = (await loadSource).replace(
@@ -153,20 +153,20 @@ async function generateTextFiles() {
     (_, filename) => {
       files.add(filename)
       return `require(${JSON.stringify(`${filename}.text.js`)})`
-    }
+    },
   )
   await fs.promises.writeFile(
     resolve(__dirname, '../dist/load.js'),
-    loadSourceWithPolyfills
+    loadSourceWithPolyfills,
   )
   for (const file of files) {
     const contents = await fs.promises.readFile(
       resolve(__dirname, '../dist', file),
-      'utf8'
+      'utf8',
     )
     await fs.promises.writeFile(
       resolve(__dirname, '../dist', `${file}.text.js`),
-      `module.exports = ${JSON.stringify(contents)}`
+      `module.exports = ${JSON.stringify(contents)}`,
     )
     // remove the original file
     await fs.promises.unlink(resolve(__dirname, '../dist', file))

--- a/packages/primitives/src/primitives/crypto.js
+++ b/packages/primitives/src/primitives/crypto.js
@@ -1,4 +1,6 @@
-import { Crypto, CryptoKey } from '@peculiar/webcrypto'
+import { webcrypto } from 'node:crypto'
+
+const { Crypto, CryptoKey } = webcrypto
 
 function SubtleCrypto() {
   if (!(this instanceof SubtleCrypto)) return new SubtleCrypto()

--- a/packages/primitives/src/primitives/events.js
+++ b/packages/primitives/src/primitives/events.js
@@ -1,7 +1,3 @@
-import { EventTarget, Event } from 'event-target-shim'
-
-export { EventTarget, Event }
-
 export class FetchEvent extends Event {
   constructor(request) {
     super('fetch')

--- a/packages/primitives/src/primitives/fetch.js
+++ b/packages/primitives/src/primitives/fetch.js
@@ -1,6 +1,3 @@
-import { AbortController } from './abort-controller'
-import { AbortSignal } from './abort-controller'
-
 import * as FetchSymbols from 'undici/lib/fetch/symbols'
 import * as HeadersModule from 'undici/lib/fetch/headers'
 import * as ResponseModule from 'undici/lib/fetch/response'
@@ -10,9 +7,6 @@ import { Request as BaseRequest } from 'undici/lib/fetch/request'
 
 import { fetch as fetchImpl } from 'undici/lib/fetch'
 import Agent from 'undici/lib/agent'
-
-global.AbortController = AbortController
-global.AbortSignal = AbortSignal
 
 // undici uses `process.nextTick`,
 // but process APIs doesn't exist in a runtime context.

--- a/packages/primitives/src/primitives/load.js
+++ b/packages/primitives/src/primitives/load.js
@@ -131,7 +131,7 @@ export function load(scopedContext = {}) {
     context,
     id: 'abort-controller.js',
     sourceCode: injectSourceCode('./abort-controller.js'),
-    scopedContext: { ...eventsImpl, ...scopedContext },
+    scopedContext: { ...scopedContext },
   })
   assign(context, {
     AbortController: abortControllerImpl.AbortController,

--- a/packages/primitives/src/primitives/load.js
+++ b/packages/primitives/src/primitives/load.js
@@ -16,7 +16,7 @@ import nodeCrypto from 'crypto'
  */
 function requireWithFakeGlobalScope(params) {
   const getModuleCode = `(function(module,exports,require,globalThis,${Object.keys(
-    params.scopedContext
+    params.scopedContext,
   ).join(',')}) {${params.sourceCode}\n})`
   const module = {
     exports: {},
@@ -26,7 +26,7 @@ function requireWithFakeGlobalScope(params) {
 
   // @ts-ignore
   const moduleRequire = (Module.createRequire || Module.createRequireFromPath)(
-    __filename
+    __filename,
   )
 
   /** @param {string} pathToRequire */
@@ -48,7 +48,7 @@ function requireWithFakeGlobalScope(params) {
     module.exports,
     throwingRequire,
     params.context,
-    ...Object.values(params.scopedContext)
+    ...Object.values(params.scopedContext),
   )
 
   return module.exports
@@ -66,7 +66,7 @@ export function load(scopedContext = {}) {
     context,
     id: 'encoding.js',
     sourceCode: injectSourceCode('./encoding.js'),
-    scopedContext: scopedContext,
+    scopedContext,
   })
   assign(context, {
     TextDecoder,
@@ -80,7 +80,7 @@ export function load(scopedContext = {}) {
     context,
     id: 'console.js',
     sourceCode: injectSourceCode('./console.js'),
-    scopedContext: scopedContext,
+    scopedContext,
   })
   assign(context, { console: consoleImpl.console })
 
@@ -89,11 +89,11 @@ export function load(scopedContext = {}) {
     context,
     id: 'events.js',
     sourceCode: injectSourceCode('./events.js'),
-    scopedContext: scopedContext,
+    scopedContext,
   })
   assign(context, {
-    Event: eventsImpl.Event,
-    EventTarget: eventsImpl.EventTarget,
+    Event,
+    EventTarget,
     FetchEvent: eventsImpl.FetchEvent,
     // @ts-expect-error we need to add this to the type definitions maybe
     PromiseRejectionEvent: eventsImpl.PromiseRejectionEvent,

--- a/packages/primitives/src/primitives/load.js
+++ b/packages/primitives/src/primitives/load.js
@@ -91,6 +91,7 @@ export function load(scopedContext = {}) {
     sourceCode: injectSourceCode('./events.js'),
     scopedContext,
   })
+
   assign(context, {
     Event,
     EventTarget,
@@ -99,31 +100,23 @@ export function load(scopedContext = {}) {
     PromiseRejectionEvent: eventsImpl.PromiseRejectionEvent,
   })
 
-  /** @type {import('../../type-definitions/streams')} */
-  const streamsImpl = requireWithFakeGlobalScope({
-    context,
-    id: 'streams.js',
-    sourceCode: injectSourceCode('./streams.js'),
-    scopedContext: { ...scopedContext },
-  })
+  const streamsImpl = {
+    ReadableStream: require('node:stream/web').ReadableStream,
+    ReadableStreamBYOBReader:
+      require('node:stream/web').ReadableStreamBYOBReader,
+    ReadableStreamDefaultReader:
+      require('node:stream/web').ReadableStreamDefaultReader,
+    TransformStream: require('node:stream/web').TransformStream,
+    WritableStream: require('node:stream/web').WritableStream,
+    WritableStreamDefaultWriter:
+      require('node:stream/web').WritableStreamDefaultWriter,
+  }
 
-  /** @type {import('../../type-definitions/text-encoding-streams')} */
-  const textEncodingStreamImpl = requireWithFakeGlobalScope({
-    context,
-    id: 'text-encoding-streams.js',
-    sourceCode: injectSourceCode('./text-encoding-streams.js'),
-    scopedContext: { ...streamsImpl, ...scopedContext },
-  })
+  assign(context, streamsImpl)
 
   assign(context, {
-    ReadableStream: streamsImpl.ReadableStream,
-    ReadableStreamBYOBReader: streamsImpl.ReadableStreamBYOBReader,
-    ReadableStreamDefaultReader: streamsImpl.ReadableStreamDefaultReader,
-    TextDecoderStream: textEncodingStreamImpl.TextDecoderStream,
-    TextEncoderStream: textEncodingStreamImpl.TextEncoderStream,
-    TransformStream: streamsImpl.TransformStream,
-    WritableStream: streamsImpl.WritableStream,
-    WritableStreamDefaultWriter: streamsImpl.WritableStreamDefaultWriter,
+    TextEncoderStream: require('node:stream/web').TextEncoderStream,
+    TextDecoderStream: require('node:stream/web').TextDecoderStream
   })
 
   /** @type {import('../../type-definitions/abort-controller')} */
@@ -163,10 +156,7 @@ export function load(scopedContext = {}) {
     }
 
     /** @type {any} */
-    const global = {
-      ...streamsImpl,
-      ...scopedContext,
-    }
+    const global = { ...streamsImpl, ...scopedContext }
 
     const globalGlobal = { ...global, Blob: undefined }
     Object.setPrototypeOf(globalGlobal, globalThis)
@@ -206,10 +196,10 @@ export function load(scopedContext = {}) {
     scopedContext: {
       global: { ...scopedContext },
       ...scopedContext,
-      ...streamsImpl,
       ...urlImpl,
       ...abortControllerImpl,
       ...eventsImpl,
+      ...streamsImpl,
       structuredClone: context.structuredClone,
     },
   })

--- a/packages/primitives/src/primitives/load.js
+++ b/packages/primitives/src/primitives/load.js
@@ -4,6 +4,17 @@
 import Module from 'module'
 import nodeCrypto from 'crypto'
 
+import {
+  ReadableStream,
+  ReadableStreamBYOBReader,
+  ReadableStreamDefaultReader,
+  TextDecoderStream,
+  TextEncoderStream,
+  TransformStream,
+  WritableStream,
+  WritableStreamDefaultWriter,
+} from 'node:stream/web'
+
 /**
  * @param {Object} params
  * @param {unknown} params.context
@@ -71,6 +82,8 @@ export function load(scopedContext = {}) {
   assign(context, {
     TextDecoder,
     TextEncoder,
+    TextEncoderStream,
+    TextDecoderStream,
     atob: encodingImpl.atob,
     btoa: encodingImpl.btoa,
   })
@@ -101,23 +114,15 @@ export function load(scopedContext = {}) {
   })
 
   const streamsImpl = {
-    ReadableStream: require('node:stream/web').ReadableStream,
-    ReadableStreamBYOBReader:
-      require('node:stream/web').ReadableStreamBYOBReader,
-    ReadableStreamDefaultReader:
-      require('node:stream/web').ReadableStreamDefaultReader,
-    TransformStream: require('node:stream/web').TransformStream,
-    WritableStream: require('node:stream/web').WritableStream,
-    WritableStreamDefaultWriter:
-      require('node:stream/web').WritableStreamDefaultWriter,
+    ReadableStream,
+    ReadableStreamBYOBReader,
+    ReadableStreamDefaultReader,
+    TransformStream,
+    WritableStream,
+    WritableStreamDefaultWriter,
   }
 
   assign(context, streamsImpl)
-
-  assign(context, {
-    TextEncoderStream: require('node:stream/web').TextEncoderStream,
-    TextDecoderStream: require('node:stream/web').TextDecoderStream
-  })
 
   /** @type {import('../../type-definitions/abort-controller')} */
   const abortControllerImpl = requireWithFakeGlobalScope({

--- a/packages/primitives/src/primitives/streams.js
+++ b/packages/primitives/src/primitives/streams.js
@@ -1,8 +1,0 @@
-export {
-  ReadableStream,
-  ReadableStreamBYOBReader,
-  ReadableStreamDefaultReader,
-  TransformStream,
-  WritableStream,
-  WritableStreamDefaultWriter,
-} from 'node:stream/web'

--- a/packages/primitives/src/primitives/streams.js
+++ b/packages/primitives/src/primitives/streams.js
@@ -5,4 +5,4 @@ export {
   TransformStream,
   WritableStream,
   WritableStreamDefaultWriter,
-} from 'web-streams-polyfill'
+} from 'node:stream/web'

--- a/packages/primitives/src/primitives/text-encoding-streams.js
+++ b/packages/primitives/src/primitives/text-encoding-streams.js
@@ -1,5 +1,2 @@
 // Must import after web-streams-polyfill
-export {
-  TextEncoderStream,
-  TextDecoderStream,
-} from '@stardazed/streams-text-encoding'
+export { TextEncoderStream, TextDecoderStream } from 'node:stream/web'

--- a/packages/primitives/src/primitives/text-encoding-streams.js
+++ b/packages/primitives/src/primitives/text-encoding-streams.js
@@ -1,2 +1,0 @@
-// Must import after web-streams-polyfill
-export { TextEncoderStream, TextDecoderStream } from 'node:stream/web'

--- a/packages/primitives/type-definitions/events.d.ts
+++ b/packages/primitives/type-definitions/events.d.ts
@@ -17,5 +17,5 @@ export declare class FetchEvent {
 export {
   EventConstructor as Event,
   EventTargetConstructor as EventTarget,
-  EventTarget as PromiseRejectionEvent
+  EventTarget as PromiseRejectionEvent,
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -40,7 +40,7 @@
     "web-streams-polyfill": "4.0.0-beta.3"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "files": [
     "dist"

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -36,8 +36,7 @@
   },
   "devDependencies": {
     "@types/node-fetch": "2",
-    "node-fetch": "2",
-    "web-streams-polyfill": "4.0.0-beta.3"
+    "node-fetch": "2"
   },
   "engines": {
     "node": ">=16"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -27,7 +27,7 @@
     "@edge-runtime/primitives": "workspace:*"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "files": [
     "src"

--- a/packages/user-agent/package.json
+++ b/packages/user-agent/package.json
@@ -31,7 +31,7 @@
     "ua-parser-js": "1.0.35"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "files": [
     "dist"

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -23,7 +23,7 @@
     "web"
   ],
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "files": [
     "dist"

--- a/packages/vm/tests/edge-runtime.test.ts
+++ b/packages/vm/tests/edge-runtime.test.ts
@@ -170,7 +170,7 @@ describe('General behaviour', () => {
             typeof input === 'string' && !input.startsWith('https://')
               ? `https://${input}`
               : String(input),
-            init
+            init,
           )
 
         return context
@@ -180,7 +180,7 @@ describe('General behaviour', () => {
     const promises = await Promise.all([
       edgeVM.evaluate<Promise<Response>>("fetch('edge-ping.vercel.app')"),
       edgeVM.evaluate<Promise<Response>>(
-        "globalThis.fetch('edge-ping.vercel.app')"
+        "globalThis.fetch('edge-ping.vercel.app')",
       ),
     ])
 
@@ -195,7 +195,7 @@ describe('Behaviour of some pre-defined APIs', () => {
   describe('`fetch`', () => {
     it('works when parsing a response as text', async () => {
       const html = await new EdgeVM().evaluate(
-        `fetch('https://example.vercel.sh').then(res => res.text())`
+        `fetch('https://example.vercel.sh').then(res => res.text())`,
       )
       expect(html.startsWith('<!doctype html>')).toBe(true)
     })
@@ -204,13 +204,13 @@ describe('Behaviour of some pre-defined APIs', () => {
       const edgeVM = new EdgeVM()
       edgeVM.evaluate('this.headers = new Headers()')
       edgeVM.evaluate(
-        "this.request = new Request('https://edge-ping.vercel.app', { headers: new Headers({ 'Content-Type': 'text/xml' }) })"
+        "this.request = new Request('https://edge-ping.vercel.app', { headers: new Headers({ 'Content-Type': 'text/xml' }) })",
       )
 
       expect(edgeVM.context.headers).toBeTruthy()
       expect(edgeVM.context.request).toBeTruthy()
       expect(edgeVM.context.request.headers.get('Content-Type')).toEqual(
-        'text/xml'
+        'text/xml',
       )
     })
 
@@ -229,7 +229,7 @@ describe('Behaviour of some pre-defined APIs', () => {
     it('allows to run within the VM reading outside of it', async () => {
       const edgeVM = new EdgeVM()
       const promise = edgeVM.evaluate<Promise<Response>>(
-        "fetch('https://edge-ping.vercel.app')"
+        "fetch('https://edge-ping.vercel.app')",
       )
 
       expect(promise).toBeTruthy()
@@ -244,7 +244,7 @@ describe('Behaviour of some pre-defined APIs', () => {
     it('works when using Uint8Array', () => {
       const edgeVM = new EdgeVM()
       edgeVM.evaluate(
-        "this.decode = new TextDecoder('utf-8', { ignoreBOM: true }).decode(new Uint8Array([101,100,103,101,45,112,105,110,103,46,118,101,114,99,101,108,46,97,112,112 ]))"
+        "this.decode = new TextDecoder('utf-8', { ignoreBOM: true }).decode(new Uint8Array([101,100,103,101,45,112,105,110,103,46,118,101,114,99,101,108,46,97,112,112 ]))",
       )
       expect(edgeVM.context.decode).toBe('edge-ping.vercel.app')
     })
@@ -352,7 +352,7 @@ describe('Behaviour of some pre-defined APIs', () => {
           'windows-1257',
           'windows-1258',
           'x-mac-cyrillic',
-        ])
+        ]),
       )
     })
   })
@@ -362,75 +362,75 @@ describe('Using `instanceof`', () => {
   it('uses the correct builtins for dependent APIs', () => {
     expect(
       new EdgeVM().evaluate(
-        `(new TextEncoder().encode('abc')) instanceof Uint8Array`
-      )
+        `(new TextEncoder().encode('abc')) instanceof Uint8Array`,
+      ),
     ).toBe(true)
     expect(
       new EdgeVM().evaluate(
-        `(new TextEncoder().encode('abc')) instanceof Object`
-      )
+        `(new TextEncoder().encode('abc')) instanceof Object`,
+      ),
     ).toBe(true)
     expect(
       new EdgeVM().evaluate(
-        `(new TextEncoder().encode('abc')) instanceof Object`
-      )
+        `(new TextEncoder().encode('abc')) instanceof Object`,
+      ),
     ).toBe(true)
     expect(
       new EdgeVM().evaluate(`
           class Foo {};
           const cls = Foo;
           cls instanceof Function;
-        `)
+        `),
     ).toEqual(true)
     expect(
       new EdgeVM().evaluate(
-        `(new TextEncoderStream()).writable instanceof WritableStream`
-      )
+        `(new TextEncoderStream()).writable instanceof WritableStream`,
+      ),
     ).toBe(true)
     expect(new EdgeVM().evaluate(`(new Uint8Array()) instanceof Object`)).toBe(
-      true
+      true,
     )
     expect(
-      new EdgeVM().evaluate(`(new AbortController()) instanceof Object`)
+      new EdgeVM().evaluate(`(new AbortController()) instanceof Object`),
     ).toBe(true)
     expect(
       new EdgeVM().evaluate(
-        `(new URL('https://example.vercel.sh')) instanceof Object`
-      )
+        `(new URL('https://example.vercel.sh')) instanceof Object`,
+      ),
     ).toBe(true)
     expect(
-      new EdgeVM().evaluate(`(new URLSearchParams()) instanceof Object`)
+      new EdgeVM().evaluate(`(new URLSearchParams()) instanceof Object`),
     ).toBe(true)
     expect(new EdgeVM().evaluate(`(new URLPattern()) instanceof Object`)).toBe(
-      true
+      true,
     )
   })
 
   it('does not alter instanceof for literals and objects', async () => {
     expect(new EdgeVM().evaluate('new Float32Array() instanceof Object')).toBe(
-      true
+      true,
     )
     expect(
-      new EdgeVM().evaluate('new Float32Array() instanceof Float32Array')
+      new EdgeVM().evaluate('new Float32Array() instanceof Float32Array'),
     ).toBe(true)
     expect(new EdgeVM().evaluate('[] instanceof Array')).toBe(true)
     expect(new EdgeVM().evaluate('new Array() instanceof Array')).toBe(true)
     expect(new EdgeVM().evaluate('/^hello$/gi instanceof RegExp')).toBe(true)
     expect(
-      new EdgeVM().evaluate('new RegExp("^hello$", "gi") instanceof RegExp')
+      new EdgeVM().evaluate('new RegExp("^hello$", "gi") instanceof RegExp'),
     ).toBe(true)
     expect(new EdgeVM().evaluate('({ foo: "bar" }) instanceof Object')).toBe(
-      true
+      true,
     )
     expect(
-      new EdgeVM().evaluate('Object.create({ foo: "bar" }) instanceof Object')
+      new EdgeVM().evaluate('Object.create({ foo: "bar" }) instanceof Object'),
     ).toBe(true)
     expect(
-      new EdgeVM().evaluate('new Object({ foo: "bar" }) instanceof Object')
+      new EdgeVM().evaluate('new Object({ foo: "bar" }) instanceof Object'),
     ).toBe(true)
     expect(new EdgeVM().evaluate('(() => {}) instanceof Function')).toBe(true)
     expect(new EdgeVM().evaluate('(function () {}) instanceof Function')).toBe(
-      true
+      true,
     )
   })
 })
@@ -614,7 +614,7 @@ describe('Event handlers', () => {
     expect(runtime.context.unhandled).toHaveBeenCalledTimes(1)
 
     runtime.evaluate(
-      `removeEventListener("unhandledrejection", self.unhandled)`
+      `removeEventListener("unhandledrejection", self.unhandled)`,
     )
     expect((runtime as any).__rejectionHandlers).toBeUndefined()
   })

--- a/packages/vm/tests/instanceof.test.ts
+++ b/packages/vm/tests/instanceof.test.ts
@@ -4,6 +4,30 @@
 
 import { EdgeVM } from '../src'
 
+it('DOMException', async () => {
+  const runtime = new EdgeVM()
+
+  const fn = async () => {
+    const error = new DOMException()
+
+    return {
+      '.constructor.name': error.constructor.name,
+      'instanceof DOMException': error instanceof DOMException,
+      'instanceof Error': error instanceof Error,
+    }
+  }
+
+  const v: Awaited<ReturnType<typeof fn>> = await runtime.evaluate(
+    `(${fn.toString()})()`,
+  )
+
+  expect(v).toEqual<typeof v>({
+    '.constructor.name': 'DOMException',
+    'instanceof DOMException': true,
+    'instanceof Error': true,
+  })
+})
+
 it('AbortController', async () => {
   const runtime = new EdgeVM()
 
@@ -14,7 +38,7 @@ it('AbortController', async () => {
       signal: controller.signal,
     }).then(
       () => Promise.reject('should not resolve'),
-      (e) => e
+      (e) => e,
     )
 
     return {
@@ -26,7 +50,7 @@ it('AbortController', async () => {
   }
 
   const v: Awaited<ReturnType<typeof fn>> = await runtime.evaluate(
-    `(${fn.toString()})()`
+    `(${fn.toString()})()`,
   )
 
   expect(v).toEqual<typeof v>({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -250,9 +250,6 @@ importers:
       urlpattern-polyfill:
         specifier: 9.0.0
         version: 9.0.0
-      web-streams-polyfill:
-        specifier: 4.0.0-beta.3
-        version: 4.0.0-beta.3
 
   packages/runtime:
     dependencies:
@@ -290,9 +287,6 @@ importers:
       node-fetch:
         specifier: '2'
         version: 2.6.11
-      web-streams-polyfill:
-        specifier: 4.0.0-beta.3
-        version: 4.0.0-beta.3
 
   packages/types:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,9 +214,6 @@ importers:
       '@ungap/structured-clone':
         specifier: 1.2.0
         version: 1.2.0
-      aggregate-error-ponyfill:
-        specifier: 1.1.0
-        version: 1.1.0
       blob-polyfill:
         specifier: 7.0.20220408
         version: 7.0.20220408
@@ -2258,13 +2255,6 @@ packages:
     resolution: {integrity: sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-
-  /aggregate-error-ponyfill@1.1.0:
-    resolution: {integrity: sha512-YLd9SK8Sl4mjwSqU+NA26d/fTE33dIrvC4XedrNj/SkRlz5ropjpwrihWX7WvIkIatGjt4JjU/qSVcdZ1T145g==}
-    engines: {node: '>=10'}
-    dependencies:
-      is-iterable: 1.1.1
-    dev: true
 
   /ansi-align@3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
@@ -4661,11 +4651,6 @@ packages:
     dependencies:
       global-dirs: 3.0.1
       is-path-inside: 3.0.3
-    dev: true
-
-  /is-iterable@1.1.1:
-    resolution: {integrity: sha512-EdOZCr0NsGE00Pot+x1ZFx9MJK3C6wy91geZpXwvwexDLJvA4nzYyZf7r+EIwSeVsOLDdBz7ATg9NqKTzuNYuQ==}
-    engines: {node: '>= 4'}
     dev: true
 
   /is-negative-zero@2.0.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
         specifier: 29.5.3
         version: 29.5.3
       '@types/node':
-        specifier: '14'
-        version: 14.18.54
+        specifier: '16'
+        version: 16.18.40
       c8:
         specifier: latest
         version: 8.0.1
@@ -33,7 +33,7 @@ importers:
         version: 1.0.46
       jest:
         specifier: 29.6.2
-        version: 29.6.2(@types/node@14.18.54)(ts-node@10.9.1)
+        version: 29.6.2(@types/node@16.18.40)(ts-node@10.9.1)
       jest-watch-typeahead:
         specifier: 2.2.2
         version: 2.2.2(jest@29.6.2)
@@ -51,7 +51,7 @@ importers:
         version: 29.1.1(@babel/core@7.20.12)(@jest/types@29.5.0)(esbuild@0.19.2)(jest@29.6.2)(typescript@5.1.6)
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@types/node@14.18.54)(typescript@5.1.6)
+        version: 10.9.1(@types/node@16.18.40)(typescript@5.1.6)
       turbo:
         specifier: latest
         version: 1.10.12
@@ -229,9 +229,6 @@ importers:
       esbuild-plugin-alias:
         specifier: latest
         version: 0.2.1
-      event-target-shim:
-        specifier: 6.0.2
-        version: 6.0.2
       formdata-node:
         specifier: 5.0.1
         version: 5.0.1
@@ -1298,7 +1295,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.1
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
       chalk: 4.1.2
       jest-message-util: 29.6.2
       jest-util: 29.6.2
@@ -1319,14 +1316,14 @@ packages:
       '@jest/test-result': 29.6.2
       '@jest/transform': 29.6.2
       '@jest/types': 29.6.1
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.8.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.5.0
-      jest-config: 29.6.2(@types/node@14.18.54)(ts-node@10.9.1)
+      jest-config: 29.6.2(@types/node@16.18.40)(ts-node@10.9.1)
       jest-haste-map: 29.6.2
       jest-message-util: 29.6.2
       jest-regex-util: 29.4.3
@@ -1364,7 +1361,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 29.6.2
       '@jest/types': 29.6.1
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
       jest-mock: 29.6.2
 
   /@jest/expect-utils@29.6.2:
@@ -1400,7 +1397,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.1
       '@sinonjs/fake-timers': 10.0.2
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
       jest-message-util: 29.6.2
       jest-mock: 29.6.2
       jest-util: 29.6.2
@@ -1431,7 +1428,7 @@ packages:
       '@jest/transform': 29.6.2
       '@jest/types': 29.6.1
       '@jridgewell/trace-mapping': 0.3.18
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
@@ -1533,7 +1530,7 @@ packages:
       '@jest/schemas': 29.4.3
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
       '@types/yargs': 17.0.22
       chalk: 4.1.2
 
@@ -1544,7 +1541,7 @@ packages:
       '@jest/schemas': 29.6.0
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
       '@types/yargs': 17.0.22
       chalk: 4.1.2
 
@@ -2023,13 +2020,13 @@ packages:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
     dependencies:
       '@types/connect': 3.4.35
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
     dev: true
 
   /@types/connect@3.4.35:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
     dev: true
 
   /@types/cookie@0.5.1:
@@ -2055,7 +2052,7 @@ packages:
   /@types/express-serve-static-core@4.17.33:
     resolution: {integrity: sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
     dev: true
@@ -2072,7 +2069,7 @@ packages:
   /@types/graceful-fs@4.1.6:
     resolution: {integrity: sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
 
   /@types/hast@2.3.4:
     resolution: {integrity: sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==}
@@ -2121,7 +2118,7 @@ packages:
   /@types/keyv@3.1.4:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
     dev: true
 
   /@types/mdast@3.0.10:
@@ -2166,6 +2163,9 @@ packages:
   /@types/node@14.18.54:
     resolution: {integrity: sha512-uq7O52wvo2Lggsx1x21tKZgqkJpvwCseBBPtX/nKQfpVlEsLOb11zZ1CRsWUKvJF0+lzuA9jwvA7Pr2Wt7i3xw==}
 
+  /@types/node@16.18.40:
+    resolution: {integrity: sha512-+yno3ItTEwGxXiS/75Q/aHaa5srkpnJaH+kdkTVJ3DtJEwv92itpKbxU+FjPoh2m/5G9zmUQfrL4A4C13c+iGA==}
+
   /@types/normalize-package-data@2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
     dev: true
@@ -2193,7 +2193,7 @@ packages:
   /@types/responselike@1.0.0:
     resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
     dev: true
 
   /@types/scheduler@0.16.2:
@@ -2208,7 +2208,7 @@ packages:
     resolution: {integrity: sha512-NUo5XNiAdULrJENtJXZZ3fHtfMolzZwczzBbnAeBbqBwG+LaG6YaJtuwzwGSQZ2wsCrxjEhNNjAkKigy3n8teQ==}
     dependencies:
       '@types/mime': 3.0.1
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
     dev: true
 
   /@types/stack-utils@2.0.1:
@@ -3797,11 +3797,6 @@ packages:
       '@types/estree': 1.0.0
     dev: false
 
-  /event-target-shim@6.0.2:
-    resolution: {integrity: sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==}
-    engines: {node: '>=10.13.0'}
-    dev: true
-
   /execa@0.8.0:
     resolution: {integrity: sha512-zDWS+Rb1E8BlqqhALSt9kUhss8Qq4nN3iof3gsOdyINksElaPyNBtKUMTR62qhvgVWR0CqCX7sdnKe4MnUbFEA==}
     engines: {node: '>=4'}
@@ -4934,7 +4929,7 @@ packages:
       '@jest/expect': 29.6.2
       '@jest/test-result': 29.6.2
       '@jest/types': 29.6.1
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.3.0
@@ -4955,7 +4950,7 @@ packages:
       - supports-color
     dev: true
 
-  /jest-cli@29.6.2(@types/node@14.18.54)(ts-node@10.9.1):
+  /jest-cli@29.6.2(@types/node@16.18.40)(ts-node@10.9.1):
     resolution: {integrity: sha512-TT6O247v6dCEX2UGHGyflMpxhnrL0DNqP2fRTKYm3nJJpCTfXX3GCMQPGFjXDoj0i5/Blp3jriKXFgdfmbYB6Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -4972,7 +4967,7 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.11
       import-local: 3.1.0
-      jest-config: 29.6.2(@types/node@14.18.54)(ts-node@10.9.1)
+      jest-config: 29.6.2(@types/node@16.18.40)(ts-node@10.9.1)
       jest-util: 29.6.2
       jest-validate: 29.6.2
       prompts: 2.4.2
@@ -4984,7 +4979,7 @@ packages:
       - ts-node
     dev: true
 
-  /jest-config@29.6.2(@types/node@14.18.54)(ts-node@10.9.1):
+  /jest-config@29.6.2(@types/node@16.18.40)(ts-node@10.9.1):
     resolution: {integrity: sha512-VxwFOC8gkiJbuodG9CPtMRjBUNZEHxwfQXmIudSTzFWxaci3Qub1ddTRbFNQlD/zUeaifLndh/eDccFX4wCMQw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -4999,7 +4994,7 @@ packages:
       '@babel/core': 7.20.12
       '@jest/test-sequencer': 29.6.2
       '@jest/types': 29.6.1
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
       babel-jest: 29.6.2(@babel/core@7.20.12)
       chalk: 4.1.2
       ci-info: 3.8.0
@@ -5019,7 +5014,7 @@ packages:
       pretty-format: 29.6.2
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1(@types/node@14.18.54)(typescript@5.1.6)
+      ts-node: 10.9.1(@types/node@16.18.40)(typescript@5.1.6)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -5059,7 +5054,7 @@ packages:
       '@jest/environment': 29.6.2
       '@jest/fake-timers': 29.6.2
       '@jest/types': 29.6.1
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
       jest-mock: 29.6.2
       jest-util: 29.6.2
     dev: true
@@ -5074,7 +5069,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.1
       '@types/graceful-fs': 4.1.6
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -5146,7 +5141,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.1
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
       jest-util: 29.6.2
 
   /jest-pnp-resolver@1.2.3(jest-resolve@29.6.2):
@@ -5199,7 +5194,7 @@ packages:
       '@jest/test-result': 29.6.2
       '@jest/transform': 29.6.2
       '@jest/types': 29.6.1
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -5230,7 +5225,7 @@ packages:
       '@jest/test-result': 29.6.2
       '@jest/transform': 29.6.2
       '@jest/types': 29.6.1
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
       chalk: 4.1.2
       cjs-module-lexer: 1.2.2
       collect-v8-coverage: 1.0.1
@@ -5292,7 +5287,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.1
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
       chalk: 4.1.2
       ci-info: 3.8.0
       graceful-fs: 4.2.11
@@ -5318,7 +5313,7 @@ packages:
     dependencies:
       ansi-escapes: 6.0.0
       chalk: 5.2.0
-      jest: 29.6.2(@types/node@14.18.54)(ts-node@10.9.1)
+      jest: 29.6.2(@types/node@16.18.40)(ts-node@10.9.1)
       jest-regex-util: 29.4.3
       jest-watcher: 29.5.0
       slash: 5.0.0
@@ -5332,7 +5327,7 @@ packages:
     dependencies:
       '@jest/test-result': 29.5.0
       '@jest/types': 29.5.0
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -5346,7 +5341,7 @@ packages:
     dependencies:
       '@jest/test-result': 29.6.2
       '@jest/types': 29.6.1
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -5358,12 +5353,12 @@ packages:
     resolution: {integrity: sha512-l3ccBOabTdkng8I/ORCkADz4eSMKejTYv1vB/Z83UiubqhC1oQ5Li6dWCyqOIvSifGjUBxuvxvlm6KGK2DtuAQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
       jest-util: 29.6.2
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  /jest@29.6.2(@types/node@14.18.54)(ts-node@10.9.1):
+  /jest@29.6.2(@types/node@16.18.40)(ts-node@10.9.1):
     resolution: {integrity: sha512-8eQg2mqFbaP7CwfsTpCxQ+sHzw1WuNWL5UUvjnWP4hx2riGz9fPSzYOaU5q8/GqWn1TfgZIVTqYJygbGbWAANg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -5376,7 +5371,7 @@ packages:
       '@jest/core': 29.6.2(ts-node@10.9.1)
       '@jest/types': 29.6.1
       import-local: 3.1.0
-      jest-cli: 29.6.2(@types/node@14.18.54)(ts-node@10.9.1)
+      jest-cli: 29.6.2(@types/node@16.18.40)(ts-node@10.9.1)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -7039,7 +7034,7 @@ packages:
     dependencies:
       lilconfig: 2.1.0
       postcss: 8.4.28
-      ts-node: 10.9.1(@types/node@14.18.54)(typescript@5.1.6)
+      ts-node: 10.9.1(@types/node@16.18.40)(typescript@5.1.6)
       yaml: 2.3.1
     dev: true
 
@@ -8185,7 +8180,7 @@ packages:
       bs-logger: 0.2.6
       esbuild: 0.19.2
       fast-json-stable-stringify: 2.1.0
-      jest: 29.6.2(@types/node@14.18.54)(ts-node@10.9.1)
+      jest: 29.6.2(@types/node@16.18.40)(ts-node@10.9.1)
       jest-util: 29.5.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -8195,7 +8190,7 @@ packages:
       yargs-parser: 21.1.1
     dev: true
 
-  /ts-node@10.9.1(@types/node@14.18.54)(typescript@5.1.6):
+  /ts-node@10.9.1(@types/node@16.18.40)(typescript@5.1.6):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -8214,7 +8209,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
-      '@types/node': 14.18.54
+      '@types/node': 16.18.40
       acorn: 8.10.0
       acorn-walk: 8.2.0
       arg: 4.1.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,9 +214,6 @@ importers:
       '@peculiar/webcrypto':
         specifier: 1.4.3
         version: 1.4.3
-      '@stardazed/streams-text-encoding':
-        specifier: 1.0.2
-        version: 1.0.2
       '@ungap/structured-clone':
         specifier: 1.2.0
         version: 1.2.0
@@ -1912,10 +1909,6 @@ packages:
     resolution: {integrity: sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==}
     dependencies:
       '@sinonjs/commons': 2.0.0
-
-  /@stardazed/streams-text-encoding@1.0.2:
-    resolution: {integrity: sha512-f2Z15BId3t44a/u21yYSGXFAkCyKocmAyduoAy7swnZ4xIfbaZlOWsgly/jDNNOuj6hYQN72UaBRe3Z/tOHfqg==}
-    dev: true
 
   /@svitejs/changesets-changelog-github-compact@1.1.0:
     resolution: {integrity: sha512-qhUGGDHcpbY2zpjW3SwqchuW8J/5EzlPFud7xNntHKA7f3a/mx5+g+ruJKFHSAiVZYo30PALt+AyhmPUNKH/Og==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,9 +211,6 @@ importers:
       '@edge-runtime/format':
         specifier: workspace:*
         version: link:../format
-      '@peculiar/webcrypto':
-        specifier: 1.4.3
-        version: 1.4.3
       '@ungap/structured-clone':
         specifier: 1.2.0
         version: 1.2.0
@@ -226,6 +223,9 @@ importers:
       esbuild-plugin-alias:
         specifier: latest
         version: 0.2.1
+      event-target-shim:
+        specifier: 6.0.2
+        version: 6.0.2
       formdata-node:
         specifier: 5.0.1
         version: 5.0.1
@@ -1859,32 +1859,6 @@ packages:
       fastq: 1.15.0
     dev: true
 
-  /@peculiar/asn1-schema@2.3.6:
-    resolution: {integrity: sha512-izNRxPoaeJeg/AyH8hER6s+H7p4itk+03QCa4sbxI3lNdseQYCuxzgsuNK8bTXChtLTjpJz6NmXKA73qLa3rCA==}
-    dependencies:
-      asn1js: 3.0.5
-      pvtsutils: 1.3.2
-      tslib: 2.5.0
-    dev: true
-
-  /@peculiar/json-schema@1.1.12:
-    resolution: {integrity: sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==}
-    engines: {node: '>=8.0.0'}
-    dependencies:
-      tslib: 2.5.0
-    dev: true
-
-  /@peculiar/webcrypto@1.4.3:
-    resolution: {integrity: sha512-VtaY4spKTdN5LjJ04im/d/joXuvLbQdgy5Z4DXF4MFZhQ+MTrejbNMkfZBp1Bs3O5+bFqnJgyGdPuZQflvIa5A==}
-    engines: {node: '>=10.12.0'}
-    dependencies:
-      '@peculiar/asn1-schema': 2.3.6
-      '@peculiar/json-schema': 1.1.12
-      pvtsutils: 1.3.2
-      tslib: 2.5.0
-      webcrypto-core: 1.7.7
-    dev: true
-
   /@popperjs/core@2.11.6:
     resolution: {integrity: sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==}
     dev: false
@@ -2437,15 +2411,6 @@ packages:
   /arrify@1.0.1:
     resolution: {integrity: sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==}
     engines: {node: '>=0.10.0'}
-    dev: true
-
-  /asn1js@3.0.5:
-    resolution: {integrity: sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      pvtsutils: 1.3.2
-      pvutils: 1.1.3
-      tslib: 2.5.0
     dev: true
 
   /astring@1.8.4:
@@ -3783,6 +3748,11 @@ packages:
     dependencies:
       '@types/estree': 1.0.0
     dev: false
+
+  /event-target-shim@6.0.2:
+    resolution: {integrity: sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==}
+    engines: {node: '>=10.13.0'}
+    dev: true
 
   /execa@0.8.0:
     resolution: {integrity: sha512-zDWS+Rb1E8BlqqhALSt9kUhss8Qq4nN3iof3gsOdyINksElaPyNBtKUMTR62qhvgVWR0CqCX7sdnKe4MnUbFEA==}
@@ -7171,17 +7141,6 @@ packages:
     resolution: {integrity: sha512-rLSBxJjP+4DQOgcJAx6RZHT2he2pkhQdSnofG5VWyVl6GRq/K02ISOuOLcsMOrtKDIJb8JN2zm3FFzWNbezdPw==}
     dev: true
 
-  /pvtsutils@1.3.2:
-    resolution: {integrity: sha512-+Ipe2iNUyrZz+8K/2IOo+kKikdtfhRKzNpQbruF2URmqPtoqAs8g3xS7TJvFF2GcPXjh7DkqMnpVveRFq4PgEQ==}
-    dependencies:
-      tslib: 2.5.0
-    dev: true
-
-  /pvutils@1.1.3:
-    resolution: {integrity: sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==}
-    engines: {node: '>=6.0.0'}
-    dev: true
-
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
     dev: true
@@ -8210,6 +8169,7 @@ packages:
 
   /tslib@2.5.0:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
+    dev: false
 
   /tsml@1.0.1:
     resolution: {integrity: sha512-3KmepnH9SUsoOVtg013CRrL7c+AK7ECaquAsJdvu4288EDJuraqBlP4PDXT/rLEJ9YDn4jqLAzRJsnFPx+V6lg==}
@@ -8709,16 +8669,6 @@ packages:
   /web-worker@1.2.0:
     resolution: {integrity: sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA==}
     dev: false
-
-  /webcrypto-core@1.7.7:
-    resolution: {integrity: sha512-7FjigXNsBfopEj+5DV2nhNpfic2vumtjjgPmeDKk45z+MJwXKKfhPB7118Pfzrmh4jqOMST6Ch37iPAHoImg5g==}
-    dependencies:
-      '@peculiar/asn1-schema': 2.3.6
-      '@peculiar/json-schema': 1.1.12
-      asn1js: 3.0.5
-      pvtsutils: 1.3.2
-      tslib: 2.5.0
-    dev: true
 
   /webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}


### PR DESCRIPTION
It drops the following polyfills:

- [x] removed `event-target-shim` (use native Event & EventTarget)
- [x] removed `@stardazed/streams-text-encoding` (use native webStreams instead)
- [x] removed `web-streams-polyfill` (use native webStreams instead)
- [x] removed `@peculiar/webcrypto` (use `require('node:crypto').webcrypto` instead)
- [x] removed `aggregate-error-ponyfill`

Closes #537