### PR TITLE
feat: revert `.getAll` removal, mark deprecated

### DIFF
--- a/.changeset/slimy-seals-confess.md
+++ b/.changeset/slimy-seals-confess.md
@@ -2,4 +2,4 @@
 '@edge-runtime/primitives': patch
 ---
 
-Reverts the removal of `Headers#getAll` introduced in #586 for compatibility reasons. It is still marked as deprecated, as `Headers.getSetCookie` is the prefferred method now.
+Reverts the removal of `Headers#getAll` introduced in #586 for compatibility reasons. It is still marked as deprecated, as `Headers.getSetCookie` is the preferred method now.

--- a/.changeset/slimy-seals-confess.md
+++ b/.changeset/slimy-seals-confess.md
@@ -1,0 +1,5 @@
+---
+'@edge-runtime/primitives': patch
+---
+
+Reverts the removal of `Headers#getAll` introduced in #586 for compatibility reasons. It is still marked as deprecated, as `Headers.getSetCookie` is the prefferred method now.

--- a/packages/integration-tests/tests/response.test.ts
+++ b/packages/integration-tests/tests/response.test.ts
@@ -12,6 +12,11 @@ test('allow to append multiple `set-cookie` header', async () => {
   response.headers.append('set-cookie', 'bar=baz')
 
   expect(response.headers.getSetCookie()).toEqual(['foo=bar', 'bar=baz'])
+
+  expect(response.headers.getAll?.('set-cookie')).toEqual([
+    'foo=bar',
+    'bar=baz',
+  ])
 })
 
 test('disallow mutate response headers for redirects', async () => {

--- a/packages/primitives/src/primitives/fetch.js
+++ b/packages/primitives/src/primitives/fetch.js
@@ -1,6 +1,8 @@
 import * as FetchSymbols from 'undici/lib/fetch/symbols'
 import * as HeadersModule from 'undici/lib/fetch/headers'
 import * as ResponseModule from 'undici/lib/fetch/response'
+import * as UtilModule from 'undici/lib/fetch/util'
+import * as WebIDLModule from 'undici/lib/fetch/webidl'
 import { Request as BaseRequest } from 'undici/lib/fetch/request'
 
 import { fetch as fetchImpl } from 'undici/lib/fetch'

--- a/packages/primitives/type-definitions/fetch.d.ts
+++ b/packages/primitives/type-definitions/fetch.d.ts
@@ -1,4 +1,7 @@
-export class Headers extends globalThis.Headers {}
+export class Headers extends globalThis.Headers {
+  /** @deprecated Use [`.getSetCookie()`](https://developer.mozilla.org/en-US/docs/Web/API/Headers/getSetCookie) instead. */
+  getAll?(key: 'set-cookie'): string[]
+}
 
 export class Request extends globalThis.Request {
   readonly headers: Headers


### PR DESCRIPTION
To introduce fewer breaking changes, this adds back the non-spec compliant `Headers#getAll` method (that was removed in #586) but still encourages the use of `Headers#getSetCookie` instead which is [part of the standard](https://fetch.spec.whatwg.org/#dom-headers-getsetcookie).

**Context:** `getAll` exists because `getSetCookie` did not exist at the time of `edge-runtime` being created.

[_We were young and needed to ship_](https://twitter.com/cramforce/status/949054860166553600).

Ref: [Slack thread](https://vercel.slack.com/archives/C03ENM5HB4K/p1694088078677229)