### PR TITLE
fix: cookies() .set() reflect priority attribute into set-cookie

### DIFF
--- a/.changeset/fifty-eagles-invite.md
+++ b/.changeset/fifty-eagles-invite.md
@@ -1,0 +1,5 @@
+---
+'@edge-runtime/cookies': patch
+---
+
+fix cookies() .set() to reflect the priority attribute into set-cookie

--- a/packages/cookies/src/serialize.ts
+++ b/packages/cookies/src/serialize.ts
@@ -14,6 +14,7 @@ export function stringifyCookie(c: ResponseCookie | RequestCookie): string {
     'secure' in c && c.secure && 'Secure',
     'httpOnly' in c && c.httpOnly && 'HttpOnly',
     'sameSite' in c && c.sameSite && `SameSite=${c.sameSite}`,
+    'priority' in c && c.priority && `Priority=${c.priority}`,
   ].filter(Boolean)
 
   return `${c.name}=${encodeURIComponent(c.value ?? '')}; ${attrs.join('; ')}`
@@ -54,10 +55,18 @@ export function parseSetCookie(setCookie: string): undefined | ResponseCookie {
   }
 
   const [[name, value], ...attributes] = parseCookie(setCookie)
-  const { domain, expires, httponly, maxage, path, samesite, secure } =
-    Object.fromEntries(
-      attributes.map(([key, value]) => [key.toLowerCase(), value]),
-    )
+  const {
+    domain,
+    expires,
+    httponly,
+    maxage,
+    path,
+    samesite,
+    secure,
+    priority,
+  } = Object.fromEntries(
+    attributes.map(([key, value]) => [key.toLowerCase(), value]),
+  )
   const cookie: ResponseCookie = {
     name,
     value: decodeURIComponent(value),
@@ -68,6 +77,7 @@ export function parseSetCookie(setCookie: string): undefined | ResponseCookie {
     path,
     ...(samesite && { sameSite: parseSameSite(samesite) }),
     ...(secure && { secure: true }),
+    ...(priority && { priority: parsePriority(priority) }),
   }
 
   return compact(cookie)
@@ -89,5 +99,14 @@ function parseSameSite(string: string): ResponseCookie['sameSite'] {
   string = string.toLowerCase()
   return SAME_SITE.includes(string as any)
     ? (string as ResponseCookie['sameSite'])
+    : undefined
+}
+
+const PRIORITY: ResponseCookie['priority'][] = ['low', 'medium', 'high']
+
+function parsePriority(string: string): ResponseCookie['priority'] {
+  string = string.toLowerCase()
+  return PRIORITY.includes(string as any)
+    ? (string as ResponseCookie['priority'])
     : undefined
 }

--- a/packages/cookies/test/response-cookies.test.ts
+++ b/packages/cookies/test/response-cookies.test.ts
@@ -64,6 +64,26 @@ test('reflect .set into `set-cookie`', async () => {
   )
 })
 
+it('reflect .set all options attributes into `set-cookie`', async () => {
+  const headers = new Headers()
+  const cookies = new ResponseCookies(headers)
+  const options = {
+    domain: 'custom-domain',
+    path: 'custom-path',
+    secure: true,
+    sameSite: 'strict' as 'strict' | 'lax' | 'none',
+    expires: new Date(2100, 0, 1, 12, 0, 0),
+    httpOnly: true,
+    maxAge: 0,
+    priority: 'high' as 'low' | 'medium' | 'high',
+  }
+  cookies.set('first-name', 'first-value', options)
+  const cookiesInHeaders = Object.fromEntries(headers.entries())['set-cookie']
+  expect(cookiesInHeaders).toBe(
+    'first-name=first-value; Path=custom-path; Expires=Fri, 01 Jan 2100 12:00:00 GMT; Max-Age=0; Domain=custom-domain; Secure; HttpOnly; SameSite=strict; Priority=high',
+  )
+})
+
 describe('`set-cookie` into .get and .getAll', () => {
   test.each([
     'name=value; Secure; HttpOnly',

--- a/packages/cookies/test/response-cookies.test.ts
+++ b/packages/cookies/test/response-cookies.test.ts
@@ -67,17 +67,16 @@ test('reflect .set into `set-cookie`', async () => {
 it('reflect .set all options attributes into `set-cookie`', async () => {
   const headers = new Headers()
   const cookies = new ResponseCookies(headers)
-  const options = {
+  cookies.set('first-name', 'first-value', {
     domain: 'custom-domain',
     path: 'custom-path',
     secure: true,
-    sameSite: 'strict' as 'strict' | 'lax' | 'none',
+    sameSite: 'strict',
     expires: new Date(2100, 0, 1, 12, 0, 0),
     httpOnly: true,
     maxAge: 0,
-    priority: 'high' as 'low' | 'medium' | 'high',
-  }
-  cookies.set('first-name', 'first-value', options)
+    priority: 'high',
+  })
   const cookiesInHeaders = Object.fromEntries(headers.entries())['set-cookie']
   expect(cookiesInHeaders).toBe(
     'first-name=first-value; Path=custom-path; Expires=Fri, 01 Jan 2100 12:00:00 GMT; Max-Age=0; Domain=custom-domain; Secure; HttpOnly; SameSite=strict; Priority=high',


### PR DESCRIPTION
Closes https://github.com/vercel/next.js/issues/56848

This PR provides the fix for cookies() .set() to reflect the priority attribute into set-cookie

RE: @balazsorban44's comment and request change on https://github.com/vercel/next.js/pull/56850 Pull Request: 

"Thanks for the PR, the @edge-runtime/cookies package is an upstream dependency, meaning it should be addressed there first, could you open these changes there, so we can bump the package here to incorporate it?

See https://github.com/vercel/edge-runtime/blob/main/packages/cookies/src/serialize.ts#L16"


