### PR TITLE
fix(btoa): it accepts any as argument

### DIFF
--- a/.changeset/olive-maps-remember.md
+++ b/.changeset/olive-maps-remember.md
@@ -1,0 +1,6 @@
+---
+"@edge-runtime/integration-tests": patch
+"@edge-runtime/primitives": patch
+---
+
+fix(btoa): it accepts any as argument

--- a/packages/integration-tests/tests/encoding.test.ts
+++ b/packages/integration-tests/tests/encoding.test.ts
@@ -26,6 +26,10 @@ test('TextDecoder with stream', () => {
 test('btoa', async () => {
   expect(btoa('Hello, world')).toBe('SGVsbG8sIHdvcmxk')
   expect(btoa(new Uint8Array([1, 2, 3]).toString())).toBe('MSwyLDM=')
+  expect(btoa(new Uint8Array([1, 2, 3]))).toBe('MSwyLDM=')
+  expect(btoa([1, 2, 3])).toBe('MSwyLDM=')
+  expect(btoa(123)).toBe('MTIz')
+  expect(btoa('123')).toBe('MTIz')
 })
 
 test('atob', async () => {

--- a/packages/primitives/src/primitives/encoding.js
+++ b/packages/primitives/src/primitives/encoding.js
@@ -1,2 +1,3 @@
 export const atob = (enc) => Buffer.from(enc, 'base64').toString('binary')
-export const btoa = (str) => Buffer.from(str, 'binary').toString('base64')
+export const btoa = (str) =>
+  Buffer.from(String(str), 'binary').toString('base64')

--- a/packages/primitives/type-definitions/encoding.d.ts
+++ b/packages/primitives/type-definitions/encoding.d.ts
@@ -5,4 +5,4 @@ export { TextEncoderConstructor as TextEncoder }
 export { TextDecoderConstructor as TextDecoder }
 
 export const atob: (encoded: string) => string
-export const btoa: (str: string) => string
+export const btoa: (input: any) => string


### PR DESCRIPTION
`btoa` can accept any value that will be cast as a string.

Closes https://github.com/vercel/edge-runtime/issues/638