### PR TITLE
fix(cookies): add fallback implementation for `Headers#getSetCookie`

### DIFF
--- a/.changeset/eight-planes-impress.md
+++ b/.changeset/eight-planes-impress.md
@@ -1,0 +1,5 @@
+---
+'@edge-runtime/cookies': patch
+---
+
+Add fallback implementation for `Headers#getSetCookie`

--- a/packages/cookies/src/response-cookies.ts
+++ b/packages/cookies/src/response-cookies.ts
@@ -1,5 +1,9 @@
 import type { ResponseCookie } from './types'
-import { parseSetCookie, stringifyCookie } from './serialize'
+import {
+  parseSetCookie,
+  splitCookiesString,
+  stringifyCookie,
+} from './serialize'
 
 /**
  * A class for manipulating {@link Response} cookies (`Set-Cookie` header).
@@ -15,7 +19,14 @@ export class ResponseCookies {
   constructor(responseHeaders: Headers) {
     this._headers = responseHeaders
 
-    const cookieStrings = responseHeaders.getSetCookie()
+    const setCookie = responseHeaders.getSetCookie?.()
+    responseHeaders.get('set-cookie') ?? []
+
+    const cookieStrings = Array.isArray(setCookie)
+      ? setCookie
+      : // TODO: remove splitCookiesString when `getSetCookie` adoption is high enough in Node.js
+        // https://developer.mozilla.org/en-US/docs/Web/API/Headers/getSetCookie#browser_compatibility
+        splitCookiesString(setCookie)
 
     for (const cookieString of cookieStrings) {
       const parsed = parseSetCookie(cookieString)

--- a/packages/cookies/src/serialize.ts
+++ b/packages/cookies/src/serialize.ts
@@ -110,3 +110,82 @@ function parsePriority(string: string): ResponseCookie['priority'] {
     ? (string as ResponseCookie['priority'])
     : undefined
 }
+
+/**
+ * @source https://github.com/nfriedly/set-cookie-parser/blob/master/lib/set-cookie.js
+ *
+ * Set-Cookie header field-values are sometimes comma joined in one string. This splits them without choking on commas
+ * that are within a single set-cookie field-value, such as in the Expires portion.
+ * This is uncommon, but explicitly allowed - see https://tools.ietf.org/html/rfc2616#section-4.2
+ * Node.js does this for every header *except* set-cookie - see https://github.com/nodejs/node/blob/d5e363b77ebaf1caf67cd7528224b651c86815c1/lib/_http_incoming.js#L128
+ * React Native's fetch does this for *every* header, including set-cookie.
+ *
+ * Based on: https://github.com/google/j2objc/commit/16820fdbc8f76ca0c33472810ce0cb03d20efe25
+ * Credits to: https://github.com/tomball for original and https://github.com/chrusart for JavaScript implementation
+ */
+export function splitCookiesString(cookiesString: string) {
+  if (!cookiesString) return []
+  var cookiesStrings = []
+  var pos = 0
+  var start
+  var ch
+  var lastComma
+  var nextStart
+  var cookiesSeparatorFound
+
+  function skipWhitespace() {
+    while (pos < cookiesString.length && /\s/.test(cookiesString.charAt(pos))) {
+      pos += 1
+    }
+    return pos < cookiesString.length
+  }
+
+  function notSpecialChar() {
+    ch = cookiesString.charAt(pos)
+
+    return ch !== '=' && ch !== ';' && ch !== ','
+  }
+
+  while (pos < cookiesString.length) {
+    start = pos
+    cookiesSeparatorFound = false
+
+    while (skipWhitespace()) {
+      ch = cookiesString.charAt(pos)
+      if (ch === ',') {
+        // ',' is a cookie separator if we have later first '=', not ';' or ','
+        lastComma = pos
+        pos += 1
+
+        skipWhitespace()
+        nextStart = pos
+
+        while (pos < cookiesString.length && notSpecialChar()) {
+          pos += 1
+        }
+
+        // currently special character
+        if (pos < cookiesString.length && cookiesString.charAt(pos) === '=') {
+          // we found cookies separator
+          cookiesSeparatorFound = true
+          // pos is inside the next cookie, so back up and return it.
+          pos = nextStart
+          cookiesStrings.push(cookiesString.substring(start, lastComma))
+          start = pos
+        } else {
+          // in param ',' or param separator ';',
+          // we continue from that comma
+          pos = lastComma + 1
+        }
+      } else {
+        pos += 1
+      }
+    }
+
+    if (!cookiesSeparatorFound || pos >= cookiesString.length) {
+      cookiesStrings.push(cookiesString.substring(start, cookiesString.length))
+    }
+  }
+
+  return cookiesStrings
+}

--- a/packages/cookies/test/response-cookies.test.ts
+++ b/packages/cookies/test/response-cookies.test.ts
@@ -59,9 +59,14 @@ test('reflect .set into `set-cookie`', async () => {
     maxAge: 0,
   })
 
-  expect(Object.fromEntries(headers.entries())['set-cookie']).toBe(
-    'foo=bar; Path=/test, fooz=barz; Path=/test2, fooHttpOnly=barHttpOnly; Path=/; HttpOnly, fooExpires=barExpires; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT, fooExpiresDate=barExpiresDate; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT, fooMaxAge=; Path=/; Max-Age=0',
-  )
+  expect(headers.getSetCookie()).toEqual([
+    'foo=bar; Path=/test',
+    'fooz=barz; Path=/test2',
+    'fooHttpOnly=barHttpOnly; Path=/; HttpOnly',
+    'fooExpires=barExpires; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT',
+    'fooExpiresDate=barExpiresDate; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT',
+    'fooMaxAge=; Path=/; Max-Age=0',
+  ])
 })
 
 it('reflect .set all options attributes into `set-cookie`', async () => {
@@ -77,10 +82,10 @@ it('reflect .set all options attributes into `set-cookie`', async () => {
     maxAge: 0,
     priority: 'high',
   })
-  const cookiesInHeaders = Object.fromEntries(headers.entries())['set-cookie']
-  expect(cookiesInHeaders).toBe(
-    'first-name=first-value; Path=custom-path; Expires=Fri, 01 Jan 2100 12:00:00 GMT; Max-Age=0; Domain=custom-domain; Secure; HttpOnly; SameSite=strict; Priority=high',
-  )
+  const cookiesInHeaders = headers.getSetCookie()
+  expect(cookiesInHeaders).toEqual([
+    'first-name=first-value; Path=custom-path; Expires=Fri, 01 Jan 2100 11:00:00 GMT; Max-Age=0; Domain=custom-domain; Secure; HttpOnly; SameSite=strict; Priority=high',
+  ])
 })
 
 describe('`set-cookie` into .get and .getAll', () => {
@@ -112,9 +117,7 @@ test('reflect .delete into `set-cookie`', async () => {
   const cookies = new ResponseCookies(headers)
 
   cookies.set('foo', 'bar')
-  expect(Object.fromEntries(headers.entries())['set-cookie']).toBe(
-    'foo=bar; Path=/',
-  )
+  expect(headers.getSetCookie()).toEqual(['foo=bar; Path=/'])
 
   expect(cookies.get('foo')?.value).toBe('bar')
   expect(cookies.get('foo')).toEqual({
@@ -124,9 +127,10 @@ test('reflect .delete into `set-cookie`', async () => {
   })
 
   cookies.set('fooz', 'barz')
-  expect(Object.fromEntries(headers)['set-cookie']).toBe(
-    'foo=bar; Path=/, fooz=barz; Path=/',
-  )
+  expect(headers.getSetCookie()).toEqual([
+    'foo=bar; Path=/',
+    'fooz=barz; Path=/',
+  ])
 
   expect(cookies.get('fooz')?.value).toBe('barz')
   expect(cookies.get('fooz')).toEqual({
@@ -136,9 +140,10 @@ test('reflect .delete into `set-cookie`', async () => {
   })
 
   cookies.delete('foo')
-  expect(Object.fromEntries(headers.entries())['set-cookie']).toBe(
-    'foo=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT, fooz=barz; Path=/',
-  )
+  expect(headers.getSetCookie()).toEqual([
+    'foo=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT',
+    'fooz=barz; Path=/',
+  ])
 
   expect(cookies.get('foo')).toEqual({
     name: 'foo',
@@ -149,9 +154,10 @@ test('reflect .delete into `set-cookie`', async () => {
 
   cookies.delete('fooz')
 
-  expect(Object.fromEntries(headers.entries())['set-cookie']).toBe(
-    'foo=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT, fooz=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT',
-  )
+  expect(headers.getSetCookie()).toEqual([
+    'foo=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT',
+    'fooz=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT',
+  ])
 
   expect(cookies.get('fooz')).toEqual({
     name: 'fooz',
@@ -166,19 +172,22 @@ test('delete cookie with domain and path', async () => {
   const cookies = new ResponseCookies(headers)
 
   cookies.delete({ name: 'foo', domain: 'example.com' })
-  expect(Object.fromEntries(headers.entries())['set-cookie']).toBe(
+  expect(headers.getSetCookie()).toEqual([
     'foo=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Domain=example.com',
-  )
+  ])
 
   cookies.delete({ name: 'bar', path: '/bar' })
-  expect(Object.fromEntries(headers.entries())['set-cookie']).toBe(
-    'foo=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Domain=example.com, bar=; Path=/bar; Expires=Thu, 01 Jan 1970 00:00:00 GMT',
-  )
+  expect(headers.getSetCookie()).toEqual([
+    'foo=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Domain=example.com',
+    'bar=; Path=/bar; Expires=Thu, 01 Jan 1970 00:00:00 GMT',
+  ])
 
   cookies.delete({ name: 'baz', path: '/bar', domain: 'example.com' })
-  expect(Object.fromEntries(headers.entries())['set-cookie']).toBe(
-    'foo=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Domain=example.com, bar=; Path=/bar; Expires=Thu, 01 Jan 1970 00:00:00 GMT, baz=; Path=/bar; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Domain=example.com',
-  )
+  expect(headers.getSetCookie()).toEqual([
+    'foo=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Domain=example.com',
+    'bar=; Path=/bar; Expires=Thu, 01 Jan 1970 00:00:00 GMT',
+    'baz=; Path=/bar; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Domain=example.com',
+  ])
 })
 
 test('options are not modified', async () => {


### PR DESCRIPTION
Partially reverts https://github.com/vercel/edge-runtime/pull/586