### PR TITLE
fix(buildToRequest): double slash path

### DIFF
--- a/packages/node-utils/src/node-to-edge/request.ts
+++ b/packages/node-utils/src/node-to-edge/request.ts
@@ -12,12 +12,12 @@ export function buildToRequest(dependencies: BuildDependencies) {
     request: IncomingMessage,
     options: RequestOptions,
   ): Request {
+    const base = computeOrigin(request, options.defaultOrigin)
     return new Request(
       String(
-        new URL(
-          request.url || '/',
-          computeOrigin(request, options.defaultOrigin),
-        ),
+        request.url?.startsWith('//')
+          ? new URL(base + request.url)
+          : new URL(request.url || '/', base),
       ),
       {
         method: request.method,

--- a/packages/node-utils/test/node-to-edge/request.test.ts
+++ b/packages/node-utils/test/node-to-edge/request.test.ts
@@ -78,6 +78,12 @@ it(`uses default origin as request url origin when there are no host header`, as
   expect(request.url).toEqual(`${server.url}/`)
 })
 
+it(`paths starting with double slashes should not reset the origin`, async () => {
+  const slashes = '//foo'
+  const request = await mapRequest(`${server.url}${slashes}`)
+  expect(request.url).toEqual(`${server.url}${slashes}`)
+})
+
 it(`uses request host header as request url origin`, async () => {
   const host = 'vercel.com'
   await expect(


### PR DESCRIPTION
This PR fixes the problem of missing origin with double slash paths.

```js
new URL("//foo.com", "https://example.com");
// => 'https://foo.com/'
```