### PR TITLE
feat(cookies): support `partitioned` attribute

### DIFF
--- a/.changeset/new-jars-live.md
+++ b/.changeset/new-jars-live.md
@@ -1,0 +1,5 @@
+---
+'@edge-runtime/cookies': minor
+---
+
+Add cookies partitioned attribute

--- a/packages/cookies/src/serialize.ts
+++ b/packages/cookies/src/serialize.ts
@@ -14,6 +14,7 @@ export function stringifyCookie(c: ResponseCookie | RequestCookie): string {
     'secure' in c && c.secure && 'Secure',
     'httpOnly' in c && c.httpOnly && 'HttpOnly',
     'sameSite' in c && c.sameSite && `SameSite=${c.sameSite}`,
+    'partitioned' in c && c.partitioned && 'Partitioned',
     'priority' in c && c.priority && `Priority=${c.priority}`,
   ].filter(Boolean)
 
@@ -63,6 +64,7 @@ export function parseSetCookie(setCookie: string): undefined | ResponseCookie {
     path,
     samesite,
     secure,
+    partitioned,
     priority,
   } = Object.fromEntries(
     attributes.map(([key, value]) => [key.toLowerCase(), value]),
@@ -78,6 +80,7 @@ export function parseSetCookie(setCookie: string): undefined | ResponseCookie {
     ...(samesite && { sameSite: parseSameSite(samesite) }),
     ...(secure && { secure: true }),
     ...(priority && { priority: parsePriority(priority) }),
+    ...(partitioned && { partitioned: true }),
   }
 
   return compact(cookie)

--- a/packages/cookies/src/types.ts
+++ b/packages/cookies/src/types.ts
@@ -7,7 +7,7 @@ import type { CookieSerializeOptions } from 'cookie'
 export interface CookieListItem
   extends Pick<
     CookieSerializeOptions,
-    'domain' | 'path' | 'secure' | 'sameSite'
+    'domain' | 'path' | 'secure' | 'sameSite' | 'partitioned'
   > {
   /** A string with the name of a cookie. */
   name: string


### PR DESCRIPTION
Chrome already started rolling/enforcing this feature (currently at 1%).