### PR TITLE
fix(cookies): cookie header format

### DIFF
--- a/.changeset/fast-hairs-pull.md
+++ b/.changeset/fast-hairs-pull.md
@@ -1,0 +1,5 @@
+---
+'@edge-runtime/cookies': patch
+---
+
+Fix cookie header format

--- a/packages/cookies/src/serialize.ts
+++ b/packages/cookies/src/serialize.ts
@@ -18,7 +18,10 @@ export function stringifyCookie(c: ResponseCookie | RequestCookie): string {
     'priority' in c && c.priority && `Priority=${c.priority}`,
   ].filter(Boolean)
 
-  return `${c.name}=${encodeURIComponent(c.value ?? '')}; ${attrs.join('; ')}`
+  const s = `${c.name}=${encodeURIComponent(c.value ?? '')}`
+  if (attrs.length === 0) return s
+
+  return `${s}; ${attrs.join('; ')}`
 }
 
 /** Parse a `Cookie` header value */

--- a/packages/cookies/src/serialize.ts
+++ b/packages/cookies/src/serialize.ts
@@ -18,10 +18,8 @@ export function stringifyCookie(c: ResponseCookie | RequestCookie): string {
     'priority' in c && c.priority && `Priority=${c.priority}`,
   ].filter(Boolean)
 
-  const s = `${c.name}=${encodeURIComponent(c.value ?? '')}`
-  if (attrs.length === 0) return s
-
-  return `${s}; ${attrs.join('; ')}`
+  const stringified = `${c.name}=${encodeURIComponent(c.value ?? '')}`
+  return attrs.length === 0 ? stringified : `${stringified}; ${attrs.join('; ')}`
 }
 
 /** Parse a `Cookie` header value */

--- a/packages/cookies/test/request-cookies.test.ts
+++ b/packages/cookies/test/request-cookies.test.ts
@@ -40,6 +40,22 @@ describe('input parsing', () => {
   })
 })
 
+describe('output serializing', () => {
+  test('single element', () => {
+    const headers = new Headers()
+    const cookies = new RequestCookies(headers)
+    cookies.set('a', '1')
+    expect(headers.get('cookie')).toBe('a=1')
+  })
+  test('multiple elements', () => {
+    const headers = new Headers()
+    const cookies = new RequestCookies(headers)
+    cookies.set('a', '1')
+    cookies.set('b', '2')
+    expect(headers.get('cookie')).toBe('a=1; b=2')
+  })
+})
+
 test('updating a cookie', () => {
   const headers = requestHeadersWithCookies('a=1; b=2')
 


### PR DESCRIPTION
- [Spec](https://datatracker.ietf.org/doc/html/rfc6265#section-4.2.1:~:text=cookie%2Dheader%20%3D%20%22Cookie%3A%22%20OWS%20cookie%2Dstring%20OWS%0A%20%20%20cookie%2Dstring%20%3D%20cookie%2Dpair%20*(%20%22%3B%22%20SP%20cookie%2Dpair%20))
- It seems incorrect to have a trailing semicolon.