### PR TITLE
perf: speed up server close

### DIFF
--- a/.changeset/afraid-seahorses-argue.md
+++ b/.changeset/afraid-seahorses-argue.md
@@ -1,0 +1,5 @@
+---
+"edge-runtime": patch
+---
+
+perf: speed up server close


### PR DESCRIPTION
Waiting `waitUntil` and closing the server can be done in parallel.