### PR TITLE
Fix splitting of concatenated Set-Cookie headers in edge-runtime package

### DIFF
--- a/.changeset/old-houses-film.md
+++ b/.changeset/old-houses-film.md
@@ -1,0 +1,7 @@
+---
+'@edge-runtime/cookies': minor
+'edge-runtime': path
+---
+
+feat(cookies): expose splitCookiesString function
+fix: splitting cookies when concatenated

--- a/packages/cookies/src/index.ts
+++ b/packages/cookies/src/index.ts
@@ -1,4 +1,9 @@
 export type { CookieListItem, RequestCookie, ResponseCookie } from './types'
 export { RequestCookies } from './request-cookies'
 export { ResponseCookies } from './response-cookies'
-export { stringifyCookie, parseCookie, parseSetCookie } from './serialize'
+export {
+  stringifyCookie,
+  parseCookie,
+  parseSetCookie,
+  splitCookiesString,
+} from './serialize'

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -24,6 +24,7 @@
     "web"
   ],
   "dependencies": {
+    "@edge-runtime/cookies": "workspace:*",
     "@edge-runtime/format": "workspace:*",
     "@edge-runtime/ponyfill": "workspace:*",
     "@edge-runtime/vm": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 importers:
 
   .:
@@ -240,6 +244,9 @@ importers:
 
   packages/runtime:
     dependencies:
+      '@edge-runtime/cookies':
+        specifier: workspace:*
+        version: link:../cookies
       '@edge-runtime/format':
         specifier: workspace:*
         version: link:../format
@@ -8645,7 +8652,3 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: false
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
Reference: 

[Issue](https://github.com/vercel/edge-runtime/issues/892)