### PR TITLE
[primitives] fix Headers#entries implementation to be consistent

### DIFF
--- a/.changeset/dirty-timers-reply.md
+++ b/.changeset/dirty-timers-reply.md
@@ -1,0 +1,21 @@
+---
+'@edge-runtime/primitives': minor
+---
+
+remove custom entries() iterator in favor of Undici's default implementation
+
+The difference will be that `set-cookie` headers will be emitted independently.
+
+```ts
+const headers = new Headers()
+headers.append('set-cookie', 'a=1')
+headers.append('set-cookie', 'b=2')
+
+const entries = [...headers.entries()]
+
+// previous implementation
+console.log(entries) // [["set-cookie", "a=1, b=2"]]
+
+// new implementation (undici's native implementation)
+console.log(entries) // [["set-cookie", "a=1"], ["set-cookie", "b=2"]]
+```

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -9,7 +9,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "http-body": "1.0.12",
     "multer": "1.4.5-lts.1",
     "test-listen": "1.1.0",
     "@types/test-listen": "1.1.2",

--- a/packages/integration-tests/test/abort-controller.test.ts
+++ b/packages/integration-tests/test/abort-controller.test.ts
@@ -1,11 +1,11 @@
-import { aboveNode16, guard } from './test-if'
+import { polyfilledOrNative, guard } from './test-if'
 
 if (!globalThis.DOMException) {
   globalThis.DOMException = require('@edge-runtime/ponyfill').DOMException
 }
 
 describe('AbortController', () => {
-  guard(it, aboveNode16)('allows to abort fetch', async () => {
+  guard(it, polyfilledOrNative)('allows to abort fetch', async () => {
     expect.assertions(1)
     const controller = new AbortController()
     controller.abort()

--- a/packages/integration-tests/test/abort-controller.test.ts
+++ b/packages/integration-tests/test/abort-controller.test.ts
@@ -1,12 +1,11 @@
+import { aboveNode16, guard } from './test-if'
+
 if (!globalThis.DOMException) {
   globalThis.DOMException = require('@edge-runtime/ponyfill').DOMException
 }
 
-const testOrSkip =
-  process.versions.node.split('.').map(Number)[0] > 16 ? test : test.skip
-
 describe('AbortController', () => {
-  testOrSkip('allows to abort fetch', async () => {
+  guard(it, aboveNode16)('allows to abort fetch', async () => {
     expect.assertions(1)
     const controller = new AbortController()
     controller.abort()

--- a/packages/integration-tests/test/body.test.ts
+++ b/packages/integration-tests/test/body.test.ts
@@ -1,92 +1,92 @@
-const testOrSkip =
-  process.versions.node.split('.').map(Number)[0] > 16 ? test : test.skip
+import { aboveNode16, guard } from './test-if'
 
-testOrSkip('throws when the body was directly consumed', async () => {
-  expect.assertions(9)
+guard(describe, aboveNode16)('body', () => {
+  test('throws when the body was directly consumed', async () => {
+    expect.assertions(9)
 
-  const object = { hello: 'world' }
-  const blob = new Blob([JSON.stringify(object, null, 2)], {
-    type: 'application/json',
-  })
+    const object = { hello: 'world' }
+    const blob = new Blob([JSON.stringify(object, null, 2)], {
+      type: 'application/json',
+    })
 
-  const formData = new FormData()
-  formData.append('name', 'John')
-  formData.append('lastname', 'Doe')
-  formData.append('metadata', blob)
+    const formData = new FormData()
+    formData.append('name', 'John')
+    formData.append('lastname', 'Doe')
+    formData.append('metadata', blob)
 
-  const response = new Response(formData)
+    const response = new Response(formData)
 
-  async function* streamToIterator<T>(
-    readable: ReadableStream<T>,
-  ): AsyncIterableIterator<T> {
-    const reader = readable.getReader()
-    while (true) {
-      const { value, done } = await reader.read()
-      if (done) break
-      if (value != null) {
-        yield value
+    async function* streamToIterator<T>(
+      readable: ReadableStream<T>,
+    ): AsyncIterableIterator<T> {
+      const reader = readable.getReader()
+      while (true) {
+        const { value, done } = await reader.read()
+        if (done) break
+        if (value != null) {
+          yield value
+        }
       }
+      reader.releaseLock()
     }
-    reader.releaseLock()
-  }
 
-  // @ts-expect-error
-  for await (const item of streamToIterator(response.body)) {
-    expect(item).toBeTruthy()
-  }
+    // @ts-expect-error
+    for await (const item of streamToIterator(response.body)) {
+      expect(item).toBeTruthy()
+    }
 
-  // @ts-expect-error
-  const reader = response.body.getReader()
-  const { done } = await reader.read()
+    // @ts-expect-error
+    const reader = response.body.getReader()
+    const { done } = await reader.read()
 
-  expect(done).toBeTruthy()
+    expect(done).toBeTruthy()
 
-  const error = await response.text().catch((err) => err)
+    const error = await response.text().catch((err) => err)
 
-  expectErrorInstanceOf(error, TypeError)
-  expect(error.message).toContain('Body is unusable')
-})
-
-testOrSkip('throws when the body was indirectly consumed', async () => {
-  expect.assertions(3)
-
-  const object = { hello: 'world' }
-  const blob = new Blob([JSON.stringify(object, null, 2)], {
-    type: 'application/json',
+    expectErrorInstanceOf(error, TypeError)
+    expect(error.message).toContain('Body is unusable')
   })
 
-  const formData = new FormData()
-  formData.append('name', 'John')
-  formData.append('lastname', 'Doe')
-  formData.append('metadata', blob)
+  test('throws when the body was indirectly consumed', async () => {
+    expect.assertions(3)
 
-  const response = new Response(formData)
-  const text = await response.text()
+    const object = { hello: 'world' }
+    const blob = new Blob([JSON.stringify(object, null, 2)], {
+      type: 'application/json',
+    })
 
-  expect(text).toBeTruthy()
+    const formData = new FormData()
+    formData.append('name', 'John')
+    formData.append('lastname', 'Doe')
+    formData.append('metadata', blob)
 
-  const error = await response.text().catch((err) => err)
+    const response = new Response(formData)
+    const text = await response.text()
 
-  expectErrorInstanceOf(error, TypeError)
-  expect(error.message).toContain('Body is unusable')
-})
+    expect(text).toBeTruthy()
 
-testOrSkip('allows to read a FormData body as text', async () => {
-  const object = { hello: 'world' }
-  const blob = new Blob([JSON.stringify(object, null, 2)], {
-    type: 'application/json',
+    const error = await response.text().catch((err) => err)
+
+    expectErrorInstanceOf(error, TypeError)
+    expect(error.message).toContain('Body is unusable')
   })
 
-  const formData = new FormData()
-  formData.append('name', 'John')
-  formData.append('lastname', 'Doe')
-  formData.append('metadata', blob)
+  test('allows to read a FormData body as text', async () => {
+    const object = { hello: 'world' }
+    const blob = new Blob([JSON.stringify(object, null, 2)], {
+      type: 'application/json',
+    })
 
-  const res = new Response(formData)
-  const text = await res?.text()
+    const formData = new FormData()
+    formData.append('name', 'John')
+    formData.append('lastname', 'Doe')
+    formData.append('metadata', blob)
 
-  expect(text.replace(/formdata-undici-0\d+/g, 'formdata-unidici-0.1234'))
-    .toMatchInlineSnapshot(`
+    const res = new Response(formData)
+    const text = await res?.text()
+
+    expect(text.replace(/formdata-undici-0\d+/g, 'formdata-unidici-0.1234'))
+      .toMatchInlineSnapshot(`
     "------formdata-unidici-0.1234
     Content-Disposition: form-data; name="name"
 
@@ -104,131 +104,129 @@ testOrSkip('allows to read a FormData body as text', async () => {
     }
     ------formdata-unidici-0.1234--"
   `)
-})
-
-testOrSkip('allows to read a null body as ArrayBuffer', async () => {
-  const response = new Response(null)
-  const buffer = await response.arrayBuffer()
-  expect(buffer.byteLength).toEqual(0)
-  expect(new Uint8Array(buffer).byteLength).toEqual(0)
-})
-
-testOrSkip('allows to read a text body as ArrayBuffer', async () => {
-  const response = new Response('Hello world')
-  const encoder = new TextEncoder()
-  const decoder = new TextDecoder()
-
-  const value = await response.arrayBuffer()
-  const decoded = decoder.decode(value)
-
-  expect(decoded).toEqual('Hello world')
-  expect(value).toEqual(encoder.encode('Hello world').buffer)
-})
-
-testOrSkip('allows to read a chunked body as ArrayBuffer', async () => {
-  const { readable, writable } = new TransformStream()
-  const encoder = new TextEncoder()
-  const writer = writable.getWriter()
-
-  void writer.write(encoder.encode('Hello '))
-  void writer.write(encoder.encode('world!'))
-  void writer.close()
-
-  const response = new Response(readable)
-  const value = await response.arrayBuffer()
-  const decoder = new TextDecoder()
-  const decoded = decoder.decode(value)
-
-  expect(decoded).toEqual('Hello world!')
-  expect(value).toEqual(encoder.encode('Hello world!').buffer)
-})
-
-testOrSkip('should pend stream data before getReader is called', async () => {
-  let startPulling = false
-  const encoder = new TextEncoder()
-  const decoder = new TextDecoder()
-
-  const readable = new ReadableStream({
-    start(controller) {
-      // delay streaming enqueue to trigger pulling
-      setTimeout(() => {
-        controller.enqueue(encoder.encode('hello'))
-        controller.enqueue(encoder.encode('world'))
-      }, 500)
-    },
-    pull() {
-      startPulling = true
-    },
   })
 
-  expect(startPulling).toBe(false)
-  const reader = readable.getReader()
+  test('allows to read a null body as ArrayBuffer', async () => {
+    const response = new Response(null)
+    const buffer = await response.arrayBuffer()
+    expect(buffer.byteLength).toEqual(0)
+    expect(new Uint8Array(buffer).byteLength).toEqual(0)
+  })
 
-  // Delay timer to trigger pulling
-  await new Promise((resolve) => setTimeout(resolve, 500))
-  // pulling should start after getReader is called
-  expect(startPulling).toBe(true)
+  test('allows to read a text body as ArrayBuffer', async () => {
+    const response = new Response('Hello world')
+    const encoder = new TextEncoder()
+    const decoder = new TextDecoder()
 
-  let result = await reader.read()
+    const value = await response.arrayBuffer()
+    const decoded = decoder.decode(value)
 
-  expect(decoder.decode(result.value)).toBe('hello')
-  result = await reader.read()
-  expect(decoder.decode(result.value)).toBe('world')
-})
+    expect(decoded).toEqual('Hello world')
+    expect(value).toEqual(encoder.encode('Hello world').buffer)
+  })
 
-testOrSkip('allows to read a URLSearchParams body as FormData', async () => {
-  const params = new URLSearchParams('q=URLUtils.searchParams&topic=api')
-  const response = new Response(params)
-  const formData = await response.formData()
-  expect(formData.get('topic')).toEqual('api')
-})
+  test('allows to read a chunked body as ArrayBuffer', async () => {
+    const { readable, writable } = new TransformStream()
+    const encoder = new TextEncoder()
+    const writer = writable.getWriter()
 
-testOrSkip('allows to read a Blob body as Blob', async () => {
-  const object = { hello: 'world' }
-  const str = JSON.stringify(object, null, 2)
-  const response = new Response(new Blob([str]))
-  const blob = await response.blob()
-  const txt = await blob.text()
-  expect(txt).toEqual(str)
-})
+    void writer.write(encoder.encode('Hello '))
+    void writer.write(encoder.encode('world!'))
+    void writer.close()
 
-testOrSkip('allows to read a text body as JSON', async () => {
-  const response = new Response(JSON.stringify({ message: 'hi', value: 10 }))
-  const value = await response.json()
-  expect(value).toEqual({ message: 'hi', value: 10 })
-})
+    const response = new Response(readable)
+    const value = await response.arrayBuffer()
+    const decoder = new TextDecoder()
+    const decoded = decoder.decode(value)
 
-testOrSkip(
-  'throws when reading a text body as JSON but it is invalid',
-  async () => {
+    expect(decoded).toEqual('Hello world!')
+    expect(value).toEqual(encoder.encode('Hello world!').buffer)
+  })
+
+  test('should pend stream data before getReader is called', async () => {
+    let startPulling = false
+    const encoder = new TextEncoder()
+    const decoder = new TextDecoder()
+
+    const readable = new ReadableStream({
+      start(controller) {
+        // delay streaming enqueue to trigger pulling
+        setTimeout(() => {
+          controller.enqueue(encoder.encode('hello'))
+          controller.enqueue(encoder.encode('world'))
+        }, 500)
+      },
+      pull() {
+        startPulling = true
+      },
+    })
+
+    expect(startPulling).toBe(false)
+    const reader = readable.getReader()
+
+    // Delay timer to trigger pulling
+    await new Promise((resolve) => setTimeout(resolve, 500))
+    // pulling should start after getReader is called
+    expect(startPulling).toBe(true)
+
+    let result = await reader.read()
+
+    expect(decoder.decode(result.value)).toBe('hello')
+    result = await reader.read()
+    expect(decoder.decode(result.value)).toBe('world')
+  })
+
+  test('allows to read a URLSearchParams body as FormData', async () => {
+    const params = new URLSearchParams('q=URLUtils.searchParams&topic=api')
+    const response = new Response(params)
+    const formData = await response.formData()
+    expect(formData.get('topic')).toEqual('api')
+  })
+
+  test('allows to read a Blob body as Blob', async () => {
+    const object = { hello: 'world' }
+    const str = JSON.stringify(object, null, 2)
+    const response = new Response(new Blob([str]))
+    const blob = await response.blob()
+    const txt = await blob.text()
+    expect(txt).toEqual(str)
+  })
+
+  test('allows to read a text body as JSON', async () => {
+    const response = new Response(JSON.stringify({ message: 'hi', value: 10 }))
+    const value = await response.json()
+    expect(value).toEqual({ message: 'hi', value: 10 })
+  })
+
+  test('throws when reading a text body as JSON but it is invalid', async () => {
     expect.assertions(2)
     const response = new Response('{ hi: "there", ')
     const error = await response.json().catch((err) => err)
     expectErrorInstanceOf(error, SyntaxError)
     expect(error.message).toContain(' in JSON at position 2')
-  },
-)
+  })
 
-testOrSkip('streams Uint8Array that can be decoded into a string', async () => {
-  const response = await fetch('https://example.vercel.sh')
-  const reader = response.body!.getReader()
-  let value: string = ''
-  const decoder = new TextDecoder()
-  while (true) {
-    const { done, value: chunk } = await reader.read()
-    if (done) {
-      break
+  test('streams Uint8Array that can be decoded into a string', async () => {
+    const response = await fetch('https://example.vercel.sh')
+    const reader = response.body!.getReader()
+    let value: string = ''
+    const decoder = new TextDecoder()
+    while (true) {
+      const { done, value: chunk } = await reader.read()
+      if (done) {
+        break
+      }
+      value += decoder.decode(chunk)
     }
-    value += decoder.decode(chunk)
-  }
-  expect(value).toContain('Example Domain')
-})
+    expect(value).toContain('Example Domain')
+  })
 
-const expectErrorInstanceOf = (error: Error, ctx: any) => {
-  if (globalThis.EdgeRuntime !== undefined) {
-    expect(error).toBeInstanceOf(ctx)
-  } else {
-    // https://github.com/jestjs/jest/issues/2549
-    expect(error.name).toBe(ctx.name)
+  const expectErrorInstanceOf = (error: Error, ctx: any) => {
+    if ((globalThis as any).EdgeRuntime !== undefined) {
+      expect(error).toBeInstanceOf(ctx)
+    } else {
+      // https://github.com/jestjs/jest/issues/2549
+      expect(error.name).toBe(ctx.name)
+    }
   }
-}
+})

--- a/packages/integration-tests/test/body.test.ts
+++ b/packages/integration-tests/test/body.test.ts
@@ -1,6 +1,6 @@
-import { aboveNode16, guard } from './test-if'
+import { polyfilledOrNative, guard } from './test-if'
 
-guard(describe, aboveNode16)('body', () => {
+guard(describe, polyfilledOrNative)('body', () => {
   test('throws when the body was directly consumed', async () => {
     expect.assertions(9)
 

--- a/packages/integration-tests/test/body.test.ts
+++ b/packages/integration-tests/test/body.test.ts
@@ -44,7 +44,7 @@ testOrSkip('throws when the body was directly consumed', async () => {
   const error = await response.text().catch((err) => err)
 
   expectErrorInstanceOf(error, TypeError)
-  expect(error.message).toEqual('Body is unusable')
+  expect(error.message).toContain('Body is unusable')
 })
 
 testOrSkip('throws when the body was indirectly consumed', async () => {
@@ -68,7 +68,7 @@ testOrSkip('throws when the body was indirectly consumed', async () => {
   const error = await response.text().catch((err) => err)
 
   expectErrorInstanceOf(error, TypeError)
-  expect(error.message).toEqual('Body is unusable')
+  expect(error.message).toContain('Body is unusable')
 })
 
 testOrSkip('allows to read a FormData body as text', async () => {

--- a/packages/integration-tests/test/crypto.test.ts
+++ b/packages/integration-tests/test/crypto.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto'
-import { aboveNode16, guard } from './test-if'
+import { polyfilledOrNative, guard } from './test-if'
 
 if (!globalThis.crypto) {
   globalThis.crypto = require('crypto')
@@ -15,7 +15,7 @@ test('crypto.randomUUID', async () => {
   expect(crypto.randomUUID()).toEqual(expect.stringMatching(/^[a-f0-9-]+$/))
 })
 
-guard(test, aboveNode16)(
+guard(test, polyfilledOrNative)(
   'crypto.subtle.digest returns a SHA-256 hash',
   async () => {
     const digest = await crypto.subtle.digest(
@@ -28,7 +28,7 @@ guard(test, aboveNode16)(
   },
 )
 
-guard(test, aboveNode16)('Ed25519', async () => {
+guard(test, polyfilledOrNative)('Ed25519', async () => {
   const kp = await crypto.subtle.generateKey('Ed25519', false, [
     'sign',
     'verify',
@@ -37,7 +37,7 @@ guard(test, aboveNode16)('Ed25519', async () => {
   expect(kp).toHaveProperty('publicKey')
 })
 
-guard(test, aboveNode16)('X25519', async () => {
+guard(test, polyfilledOrNative)('X25519', async () => {
   const kp = await crypto.subtle.generateKey('X25519', false, [
     'deriveBits',
     'deriveKey',

--- a/packages/integration-tests/test/crypto.test.ts
+++ b/packages/integration-tests/test/crypto.test.ts
@@ -1,11 +1,9 @@
 import { createHash } from 'crypto'
+import { aboveNode16, guard } from './test-if'
 
 if (!globalThis.crypto) {
   globalThis.crypto = require('crypto')
 }
-
-const testOrSkip =
-  process.versions.node.split('.').map(Number)[0] > 16 ? test : test.skip
 
 function toHex(buffer: ArrayBuffer) {
   return Array.from(new Uint8Array(buffer))
@@ -17,17 +15,20 @@ test('crypto.randomUUID', async () => {
   expect(crypto.randomUUID()).toEqual(expect.stringMatching(/^[a-f0-9-]+$/))
 })
 
-testOrSkip('crypto.subtle.digest returns a SHA-256 hash', async () => {
-  const digest = await crypto.subtle.digest(
-    'SHA-256',
-    new Uint8Array([104, 105, 33]),
-  )
-  expect(toHex(digest)).toEqual(
-    createHash('sha256').update('hi!').digest('hex'),
-  )
-})
+guard(test, aboveNode16)(
+  'crypto.subtle.digest returns a SHA-256 hash',
+  async () => {
+    const digest = await crypto.subtle.digest(
+      'SHA-256',
+      new Uint8Array([104, 105, 33]),
+    )
+    expect(toHex(digest)).toEqual(
+      createHash('sha256').update('hi!').digest('hex'),
+    )
+  },
+)
 
-testOrSkip('Ed25519', async () => {
+guard(test, aboveNode16)('Ed25519', async () => {
   const kp = await crypto.subtle.generateKey('Ed25519', false, [
     'sign',
     'verify',
@@ -36,7 +37,7 @@ testOrSkip('Ed25519', async () => {
   expect(kp).toHaveProperty('publicKey')
 })
 
-testOrSkip('X25519', async () => {
+guard(test, aboveNode16)('X25519', async () => {
   const kp = await crypto.subtle.generateKey('X25519', false, [
     'deriveBits',
     'deriveKey',

--- a/packages/integration-tests/test/env.d.ts
+++ b/packages/integration-tests/test/env.d.ts
@@ -1,0 +1,17 @@
+declare module 'multer' {
+  declare const multer: {
+    (args: any): any
+    memoryStorage: (args?: any) => any
+  }
+  export = multer
+}
+
+interface Headers {
+  /**
+   * This method is polyfilled in Edge Runtime,
+   * and therefore might exist and might not exist in runtime.
+   *
+   * @deprecated use {@link Headers.getSetCookie}
+   */
+  getAll?(name: 'set-cookie' | (string & {})): string[]
+}

--- a/packages/integration-tests/test/env.d.ts
+++ b/packages/integration-tests/test/env.d.ts
@@ -15,3 +15,8 @@ interface Headers {
    */
   getAll?(name: 'set-cookie' | (string & {})): string[]
 }
+
+class WeakRef<T> {
+  deref(): T | undefined
+  constructor(value: T)
+}

--- a/packages/integration-tests/test/fetch.test.ts
+++ b/packages/integration-tests/test/fetch.test.ts
@@ -1,15 +1,49 @@
-import { Server, createServer, IncomingMessage, ServerResponse } from 'http'
+import {
+  Server,
+  createServer as nativeCreateServer,
+  IncomingMessage,
+  ServerResponse,
+} from 'http'
 import listen from 'test-listen'
 import multer from 'multer'
 import consume from 'stream/consumers'
-import { aboveNode16, guard, isEdgeRuntime } from './test-if'
+import { polyfilledOrNative, guard, isEdgeRuntime } from './test-if'
+import { Duplex } from 'stream'
+
+/**
+ * Creates a server that its .close function
+ * kills all the sockets that are still open.
+ */
+const createServer = (
+  handler: (req: IncomingMessage, res: ServerResponse) => Promise<void> | void,
+) => {
+  const server = nativeCreateServer(handler)
+  const sockets = new Set<WeakRef<Duplex>>()
+  server.on('request', (req) => {
+    sockets.add(new WeakRef(req.socket))
+  })
+  const previousClose = server.close
+  server.close = (cb) => {
+    for (const socket of sockets) {
+      const s = socket.deref()
+      if (s) {
+        s.destroy()
+      }
+    }
+    return previousClose.call(server, cb)
+  }
+  return server
+}
 
 let server: Server
 afterEach(
-  () => new Promise((resolve) => server?.close(resolve) ?? resolve(undefined)),
+  () =>
+    new Promise((resolve) => {
+      server?.close(resolve) ?? resolve(undefined)
+    }),
 )
 
-guard(describe, aboveNode16())('fetch', () => {
+guard(describe, polyfilledOrNative())('fetch', () => {
   test('perform a GET', async () => {
     server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
       if (req.method !== 'GET') {
@@ -144,7 +178,7 @@ guard(describe, aboveNode16())('fetch', () => {
   })
 })
 
-guard(test, aboveNode16() && isEdgeRuntime())(
+guard(test, polyfilledOrNative() && isEdgeRuntime())(
   'sets headers unsupported in undici',
   async () => {
     const url = new URL('/', 'https://example.vercel.sh')

--- a/packages/integration-tests/test/headers.test.ts
+++ b/packages/integration-tests/test/headers.test.ts
@@ -1,17 +1,23 @@
-import { aboveNode16, guard, isEdgeRuntime } from './test-if'
+import { guard, isEdgeRuntime, polyfilledOrNative } from './test-if'
 
-guard(it, aboveNode16)('sets header calling Headers constructor', async () => {
-  const headers = new Headers({ cookie: 'hello=world' })
-  expect(headers.get('cookie')).toBe('hello=world')
-})
+guard(it, polyfilledOrNative)(
+  'sets header calling Headers constructor',
+  async () => {
+    const headers = new Headers({ cookie: 'hello=world' })
+    expect(headers.get('cookie')).toBe('hello=world')
+  },
+)
 
-guard(it, aboveNode16)('sets header calling Headers constructor', async () => {
-  const headers = new Headers()
-  headers.set('cookie', 'hello=world')
-  expect(headers.get('cookie')).toBe('hello=world')
-})
+guard(it, polyfilledOrNative)(
+  'sets header calling Headers constructor',
+  async () => {
+    const headers = new Headers()
+    headers.set('cookie', 'hello=world')
+    expect(headers.get('cookie')).toBe('hello=world')
+  },
+)
 
-guard(it, aboveNode16)('multiple headers', async () => {
+guard(it, polyfilledOrNative)('multiple headers', async () => {
   const headers = new Headers()
   headers.append('set-cookie', 'foo=chocochip')
   headers.append('set-cookie', 'bar=chocochip')
@@ -37,7 +43,7 @@ guard(describe, isEdgeRuntime())('getAll', () => {
   })
 })
 
-guard(describe, aboveNode16)('iterators', () => {
+guard(describe, polyfilledOrNative)('iterators', () => {
   const generate = () => {
     const headers = new Headers()
     headers.append('a', '1')

--- a/packages/integration-tests/test/headers.test.ts
+++ b/packages/integration-tests/test/headers.test.ts
@@ -1,18 +1,17 @@
-const testOrSkip =
-  process.versions.node.split('.').map(Number)[0] > 16 ? test : test.skip
+import { aboveNode16, guard, isEdgeRuntime } from './test-if'
 
-testOrSkip('sets header calling Headers constructor', async () => {
+guard(it, aboveNode16)('sets header calling Headers constructor', async () => {
   const headers = new Headers({ cookie: 'hello=world' })
   expect(headers.get('cookie')).toBe('hello=world')
 })
 
-testOrSkip('sets header calling Headers constructor', async () => {
+guard(it, aboveNode16)('sets header calling Headers constructor', async () => {
   const headers = new Headers()
   headers.set('cookie', 'hello=world')
   expect(headers.get('cookie')).toBe('hello=world')
 })
 
-testOrSkip('multiple headers', async () => {
+guard(it, aboveNode16)('multiple headers', async () => {
   const headers = new Headers()
   headers.append('set-cookie', 'foo=chocochip')
   headers.append('set-cookie', 'bar=chocochip')
@@ -21,4 +20,55 @@ testOrSkip('multiple headers', async () => {
     ['set-cookie', 'foo=chocochip'],
     ['set-cookie', 'bar=chocochip'],
   ])
+})
+
+guard(describe, isEdgeRuntime())('getAll', () => {
+  test('on set-cookie', () => {
+    const headers = new Headers()
+    headers.append('set-cookie', 'a=1')
+    headers.append('set-cookie', 'b=2')
+    expect(headers.getSetCookie()).toEqual(['a=1', 'b=2'])
+    expect(headers.getAll?.('set-cookie')).toEqual(['a=1', 'b=2'])
+  })
+
+  test('on any other name', () => {
+    const headers = new Headers()
+    expect(() => headers.getAll?.('other')).toThrow(/getAll can only be used/)
+  })
+})
+
+describe('iterators', () => {
+  const generate = () => {
+    const headers = new Headers()
+    headers.append('a', '1')
+    headers.append('b', '2')
+    headers.append('set-cookie', 'c=3')
+    headers.append('set-cookie', 'd=4')
+    return headers
+  }
+
+  test('#Symbol.iterator', () => {
+    const entries = [...generate()]
+    expect(entries).toEqual([
+      ['a', '1'],
+      ['b', '2'],
+      ['set-cookie', 'c=3'],
+      ['set-cookie', 'd=4'],
+    ])
+  })
+
+  test('#entries', () => {
+    const entries = [...generate().entries()]
+    expect(entries).toEqual([
+      ['a', '1'],
+      ['b', '2'],
+      ['set-cookie', 'c=3'],
+      ['set-cookie', 'd=4'],
+    ])
+  })
+
+  test('#values', () => {
+    const values = [...generate().values()]
+    expect(values).toEqual(['1', '2', 'c=3', 'd=4'])
+  })
 })

--- a/packages/integration-tests/test/headers.test.ts
+++ b/packages/integration-tests/test/headers.test.ts
@@ -37,7 +37,7 @@ guard(describe, isEdgeRuntime())('getAll', () => {
   })
 })
 
-describe('iterators', () => {
+guard(describe, aboveNode16)('iterators', () => {
   const generate = () => {
     const headers = new Headers()
     headers.append('a', '1')

--- a/packages/integration-tests/test/request.test.ts
+++ b/packages/integration-tests/test/request.test.ts
@@ -1,6 +1,6 @@
-import { aboveNode16, guard } from './test-if'
+import { polyfilledOrNative, guard } from './test-if'
 
-guard(describe, aboveNode16)('request', () => {
+guard(describe, polyfilledOrNative)('request', () => {
   test('evaluate promise', () => {
     const url = 'https://vercel.com/foo/bar?one=value'
     const req = new Request(url)

--- a/packages/integration-tests/test/request.test.ts
+++ b/packages/integration-tests/test/request.test.ts
@@ -1,100 +1,101 @@
-const testOrSkip =
-  process.versions.node.split('.').map(Number)[0] > 16 ? test : test.skip
+import { aboveNode16, guard } from './test-if'
 
-testOrSkip('evaluate promise', () => {
-  const url = 'https://vercel.com/foo/bar?one=value'
-  const req = new Request(url)
-  expect(req.url).toEqual(url)
-})
-
-testOrSkip('parses and reconstructs the URL alone', () => {
-  const url = 'https://vercel.com/foo/bar?one=value'
-  const req = new Request(url)
-  expect(req.url).toEqual(url)
-})
-
-testOrSkip('throws when the URL is malformed', () => {
-  try {
-    void new Request('meeeh')
-  } catch (error: any) {
-    expect(error.message).toEqual('Failed to parse URL from meeeh')
-  }
-})
-
-testOrSkip('Request.referrer is `about:client` by default', () => {
-  const request = new Request('https://example.vercel.sh')
-  expect(request.referrer).toEqual('about:client')
-})
-
-testOrSkip('Request.referrer can be customized', () => {
-  const request = new Request('https://example.vercel.sh', {
-    referrer: 'https://vercel.com/home',
-  })
-  expect(request.referrer).toEqual('https://vercel.com/home')
-})
-
-testOrSkip('create a Request instance using second argument', () => {
-  expect(
-    new Request(
-      'https://example.vercel.sh',
-      new Request('https://example.vercel.sh', { method: 'POST' }),
-    ).method,
-  ).toBe('POST')
-})
-
-testOrSkip('combine with fetch', async () => {
-  const request = new Request('https://example.vercel.sh')
-  const response = await fetch(request)
-  const body = await response.text()
-  expect(typeof body === 'string').toBe(true)
-})
-
-testOrSkip('combine with Headers', async () => {
-  const headers = new Headers({ cookie: 'hello=world' })
-  const request = new Request('https://example.vercel.sh', {
-    headers,
-  })
-  expect(request.headers.get('cookie')).toBe('hello=world')
-})
-
-testOrSkip('serialize body into JSON', async () => {
-  const obj = { hello: 'world' }
-  const request = new Request('https://example.vercel.sh', {
-    method: 'POST',
-    body: JSON.stringify(obj),
+guard(describe, aboveNode16)('request', () => {
+  test('evaluate promise', () => {
+    const url = 'https://vercel.com/foo/bar?one=value'
+    const req = new Request(url)
+    expect(req.url).toEqual(url)
   })
 
-  const data = await request.json()
-  expect(data).toEqual(obj)
-})
+  test('parses and reconstructs the URL alone', () => {
+    const url = 'https://vercel.com/foo/bar?one=value'
+    const req = new Request(url)
+    expect(req.url).toEqual(url)
+  })
 
-testOrSkip('adds duplex: half to all requests', () => {
-  const request = new Request('https://example.vercel.sh')
-  expect(request.duplex).toBe('half')
-})
+  test('throws when the URL is malformed', () => {
+    try {
+      void new Request('meeeh')
+    } catch (error: any) {
+      expect(error.message).toEqual('Failed to parse URL from meeeh')
+    }
+  })
 
-testOrSkip('can be extended', async () => {
-  class SubRequest extends Request {
-    constructor(input: Request | string, init?: RequestInit) {
-      super(input, init)
+  test('Request.referrer is `about:client` by default', () => {
+    const request = new Request('https://example.vercel.sh')
+    expect(request.referrer).toEqual('about:client')
+  })
+
+  test('Request.referrer can be customized', () => {
+    const request = new Request('https://example.vercel.sh', {
+      referrer: 'https://vercel.com/home',
+    })
+    expect(request.referrer).toEqual('https://vercel.com/home')
+  })
+
+  test('create a Request instance using second argument', () => {
+    expect(
+      new Request(
+        'https://example.vercel.sh',
+        new Request('https://example.vercel.sh', { method: 'POST' }),
+      ).method,
+    ).toBe('POST')
+  })
+
+  test('combine with fetch', async () => {
+    const request = new Request('https://example.vercel.sh')
+    const response = await fetch(request)
+    const body = await response.text()
+    expect(typeof body === 'string').toBe(true)
+  })
+
+  test('combine with Headers', async () => {
+    const headers = new Headers({ cookie: 'hello=world' })
+    const request = new Request('https://example.vercel.sh', {
+      headers,
+    })
+    expect(request.headers.get('cookie')).toBe('hello=world')
+  })
+
+  test('serialize body into JSON', async () => {
+    const obj = { hello: 'world' }
+    const request = new Request('https://example.vercel.sh', {
+      method: 'POST',
+      body: JSON.stringify(obj),
+    })
+
+    const data = await request.json()
+    expect(data).toEqual(obj)
+  })
+
+  test('adds duplex: half to all requests', () => {
+    const request = new Request('https://example.vercel.sh')
+    expect(request.duplex).toBe('half')
+  })
+
+  test('can be extended', async () => {
+    class SubRequest extends Request {
+      constructor(input: Request | string, init?: RequestInit) {
+        super(input, init)
+      }
+
+      myField = 'default value'
+
+      setField(value: string) {
+        this.myField = value
+      }
     }
 
-    myField = 'default value'
+    const request = new SubRequest('https://example.vercel.sh', {
+      headers: { 'x-test': 'hello' },
+    })
 
-    setField(value: string) {
-      this.myField = value
-    }
-  }
+    expect(request.duplex).toBe('half')
+    expect(request.myField).toBe('default value')
+    request.setField('new value')
+    expect(request.myField).toBe('new value')
 
-  const request = new SubRequest('https://example.vercel.sh', {
-    headers: { 'x-test': 'hello' },
+    expect(request.headers.get('x-test')).toBe('hello')
+    expect(request).toBeInstanceOf(Request)
   })
-
-  expect(request.duplex).toBe('half')
-  expect(request.myField).toBe('default value')
-  request.setField('new value')
-  expect(request.myField).toBe('new value')
-
-  expect(request.headers.get('x-test')).toBe('hello')
-  expect(request).toBeInstanceOf(Request)
 })

--- a/packages/integration-tests/test/response.test.ts
+++ b/packages/integration-tests/test/response.test.ts
@@ -1,69 +1,70 @@
-const testOrSkip =
-  process.versions.node.split('.').map(Number)[0] > 16 ? test : test.skip
+import { aboveNode16, guard, isEdgeRuntime } from './test-if'
 
-testOrSkip('create a response', async () => {
-  const res1 = new Response('Hello world!')
-  expect(await res1.text()).toEqual('Hello world!')
-})
+guard(describe, aboveNode16)('response', () => {
+  test('create a response', async () => {
+    const res1 = new Response('Hello world!')
+    expect(await res1.text()).toEqual('Hello world!')
+  })
 
-testOrSkip('clones responses', async () => {
-  const { readable, writable } = new TransformStream()
-  const encoder = new TextEncoder()
-  const writer = writable.getWriter()
+  test('clones responses', async () => {
+    const { readable, writable } = new TransformStream()
+    const encoder = new TextEncoder()
+    const writer = writable.getWriter()
 
-  void writer.write(encoder.encode('Hello '))
-  void writer.write(encoder.encode('world!'))
-  void writer.close()
+    void writer.write(encoder.encode('Hello '))
+    void writer.write(encoder.encode('world!'))
+    void writer.close()
 
-  const res1 = new Response(readable)
-  const res2 = res1.clone()
+    const res1 = new Response(readable)
+    const res2 = res1.clone()
 
-  expect(await res1.text()).toEqual('Hello world!')
-  expect(await res2.text()).toEqual('Hello world!')
-})
+    expect(await res1.text()).toEqual('Hello world!')
+    expect(await res2.text()).toEqual('Hello world!')
+  })
 
-testOrSkip('reads response body as buffer', async () => {
-  const response = await fetch('https://example.vercel.sh')
-  const arrayBuffer = await response.arrayBuffer()
-  const text = new TextDecoder().decode(arrayBuffer)
-  expect(text).toMatch(/^<!doctype html>/i)
+  test('reads response body as buffer', async () => {
+    const response = await fetch('https://example.vercel.sh')
+    const arrayBuffer = await response.arrayBuffer()
+    const text = new TextDecoder().decode(arrayBuffer)
+    expect(text).toMatch(/^<!doctype html>/i)
 
-  const doctype = new TextEncoder().encode('<!doctype html>')
-  const partial = new Uint8Array(arrayBuffer).slice(0, doctype.length)
+    const doctype = new TextEncoder().encode('<!doctype html>')
+    const partial = new Uint8Array(arrayBuffer).slice(0, doctype.length)
 
-  expect([...partial]).toEqual([...new Uint8Array(doctype)])
-})
+    expect([...partial]).toEqual([...new Uint8Array(doctype)])
+  })
 
-testOrSkip('allow to set `set-cookie` header', async () => {
-  const response = new Response(null)
-  response.headers.set('set-cookie', 'foo=bar')
-  expect(response.headers.get('set-cookie')).toEqual('foo=bar')
-})
-;(globalThis.EdgeRuntime !== undefined ? testOrSkip : test.skip)(
-  'allow to append multiple `set-cookie` header',
-  async () => {
+  test('allow to set `set-cookie` header', async () => {
     const response = new Response(null)
-    response.headers.append('set-cookie', 'foo=bar')
-    response.headers.append('set-cookie', 'bar=baz')
+    response.headers.set('set-cookie', 'foo=bar')
+    expect(response.headers.get('set-cookie')).toEqual('foo=bar')
+  })
 
-    expect(response.headers.getSetCookie()).toEqual(['foo=bar', 'bar=baz'])
+  guard(test, isEdgeRuntime)(
+    'allow to append multiple `set-cookie` header',
+    async () => {
+      const response = new Response(null)
+      response.headers.append('set-cookie', 'foo=bar')
+      response.headers.append('set-cookie', 'bar=baz')
+      expect(response.headers.getSetCookie()).toEqual(['foo=bar', 'bar=baz'])
+      expect(response.headers.getAll?.('set-cookie')).toEqual([
+        'foo=bar',
+        'bar=baz',
+      ])
+    },
+  )
 
-    expect(response.headers.getAll?.('set-cookie')).toEqual([
-      'foo=bar',
-      'bar=baz',
-    ])
-  },
-)
+  test('disallow mutate response headers for redirects', async () => {
+    const response = Response.redirect('https://edge-ping.vercel.app/')
+    expect(() => response.headers.set('foo', 'bar')).toThrow('immutable')
+  })
 
-testOrSkip('disallow mutate response headers for redirects', async () => {
-  const response = Response.redirect('https://edge-ping.vercel.app/')
-  expect(() => response.headers.set('foo', 'bar')).toThrow('immutable')
+  guard(test, isEdgeRuntime)(
+    'allow to mutate response headers for error',
+    async () => {
+      const response = Response.error()
+      response.headers.set('foo', 'bar')
+      expect(response.headers.get('foo')).toEqual('bar')
+    },
+  )
 })
-;(globalThis.EdgeRuntime !== undefined ? testOrSkip : test.skip)(
-  'allow to mutate response headers for error',
-  async () => {
-    const response = Response.error()
-    response.headers.set('foo', 'bar')
-    expect(response.headers.get('foo')).toEqual('bar')
-  },
-)

--- a/packages/integration-tests/test/response.test.ts
+++ b/packages/integration-tests/test/response.test.ts
@@ -1,6 +1,6 @@
-import { aboveNode16, guard, isEdgeRuntime } from './test-if'
+import { polyfilledOrNative, guard, isEdgeRuntime } from './test-if'
 
-guard(describe, aboveNode16)('response', () => {
+guard(describe, polyfilledOrNative)('response', () => {
   test('create a response', async () => {
     const res1 = new Response('Hello world!')
     expect(await res1.text()).toEqual('Hello world!')

--- a/packages/integration-tests/test/test-if.ts
+++ b/packages/integration-tests/test/test-if.ts
@@ -3,7 +3,23 @@ export const guard = <T extends { skip: T }>(
   conditional: boolean | (() => boolean),
 ): T =>
   (typeof conditional === 'function' ? conditional() : conditional) ? t : t.skip
-export const aboveNode16 = () =>
-  process.versions.node.split('.').map(Number)[0] > 16
+
+const aboveNode16 = () => process.versions.node.split('.').map(Number)[0] > 16
+
 export const isEdgeRuntime = () =>
   (globalThis as { EdgeRuntime?: unknown }).EdgeRuntime !== undefined
+
+/**
+ * Returns true if the block should execute for a Node.js version
+ * that supports the APIs natively, or in an Edge Runtime running
+ * in a Node.js version that supports it.
+ *
+ * For instance, {@link Headers} is not available in Node.js 16.x,
+ * but when running in an Edge Runtime context within Node.js 16,
+ * Headers _is_ available.
+ *
+ * Therefore, `polyfilledOrNative` will return `true` in
+ * Node.js 18.x and above, and in Edge Runtime running in Node.js 16.x
+ * and above.
+ */
+export const polyfilledOrNative = () => isEdgeRuntime() || aboveNode16()

--- a/packages/integration-tests/test/test-if.ts
+++ b/packages/integration-tests/test/test-if.ts
@@ -1,0 +1,9 @@
+export const guard = <T extends { skip: T }>(
+  t: T,
+  conditional: boolean | (() => boolean),
+): T =>
+  (typeof conditional === 'function' ? conditional() : conditional) ? t : t.skip
+export const aboveNode16 = () =>
+  process.versions.node.split('.').map(Number)[0] > 16
+export const isEdgeRuntime = () =>
+  (globalThis as { EdgeRuntime?: unknown }).EdgeRuntime !== undefined

--- a/packages/primitives/src/primitives/fetch.js
+++ b/packages/primitives/src/primitives/fetch.js
@@ -19,33 +19,6 @@ class Request extends BaseRequest {
   }
 }
 
-const __entries = HeadersModule.Headers.prototype.entries
-HeadersModule.Headers.prototype.entries = function* () {
-  let sentSetCookie = false
-  for (const [key, value] of __entries.call(this)) {
-    if (key === 'set-cookie') {
-      if (sentSetCookie) {
-        continue
-      }
-      sentSetCookie = true
-      const cookies = this.getSetCookie()
-      yield [key, cookies.join(', ')]
-    } else {
-      yield [key, value]
-    }
-  }
-}
-
-HeadersModule.Headers[Symbol.iterator] = () => {
-  return HeadersModule.Headers.prototype.entries()
-}
-
-HeadersModule.Headers.prototype.values = function* () {
-  for (const [, value] of __entries.call(this)) {
-    yield value
-  }
-}
-
 /**
  * Method for retrieving all independent `set-cookie` headers that
  * may have been appended. This will only work when getting `set-cookie`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,25 +42,25 @@ importers:
         version: 0.8.0
       next:
         specifier: latest
-        version: 14.2.4(@babel/core@7.20.12)(react-dom@18.3.1)(react@18.3.1)
+        version: 14.2.5(@babel/core@7.20.12)(react-dom@18.3.1)(react@18.3.1)
       prettier:
         specifier: latest
-        version: 3.3.2
+        version: 3.3.3
       simple-git-hooks:
         specifier: latest
         version: 2.8.0
       ts-jest:
         specifier: 29.2.2
-        version: 29.2.2(@babel/core@7.20.12)(@jest/types@29.5.0)(esbuild@0.23.0)(jest@29.7.0)(typescript@5.5.3)
+        version: 29.2.2(@babel/core@7.20.12)(@jest/types@29.5.0)(esbuild@0.23.0)(jest@29.7.0)(typescript@5.5.4)
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@types/node@16.18.40)(typescript@5.5.3)
+        version: 10.9.2(@types/node@16.18.40)(typescript@5.5.4)
       turbo:
         specifier: latest
         version: 2.0.6
       typescript:
         specifier: latest
-        version: 5.5.3
+        version: 5.5.4
 
   docs:
     dependencies:
@@ -112,13 +112,13 @@ importers:
         version: 0.6.0
       tsup:
         specifier: '8'
-        version: 8.0.1(ts-node@10.9.2)(typescript@5.5.3)
+        version: 8.0.1(ts-node@10.9.2)(typescript@5.5.4)
 
   packages/format:
     devDependencies:
       tsup:
         specifier: '8'
-        version: 8.0.1(ts-node@10.9.2)(typescript@5.5.3)
+        version: 8.0.1(ts-node@10.9.2)(typescript@5.5.4)
 
   packages/integration-tests:
     devDependencies:
@@ -131,9 +131,6 @@ importers:
       '@types/test-listen':
         specifier: 1.1.2
         version: 1.1.2
-      http-body:
-        specifier: 1.0.12
-        version: 1.0.12
       multer:
         specifier: 1.4.5-lts.1
         version: 1.4.5-lts.1
@@ -188,7 +185,7 @@ importers:
         version: 1.1.0
       tsup:
         specifier: '8'
-        version: 8.0.1(ts-node@10.9.2)(typescript@5.5.3)
+        version: 8.0.1(ts-node@10.9.2)(typescript@5.5.4)
 
   packages/ponyfill:
     devDependencies:
@@ -233,7 +230,7 @@ importers:
         version: 6.0.2
       tsup:
         specifier: '8'
-        version: 8.0.1(ts-node@10.9.2)(typescript@5.5.3)
+        version: 8.0.1(ts-node@10.9.2)(typescript@5.5.4)
       undici:
         specifier: 5.23.0
         version: 5.23.0
@@ -294,7 +291,7 @@ importers:
         version: 0.7.39
       tsup:
         specifier: '8'
-        version: 8.0.1(ts-node@10.9.2)(typescript@5.5.3)
+        version: 8.0.1(ts-node@10.9.2)(typescript@5.5.4)
       ua-parser-js:
         specifier: 1.0.38
         version: 1.0.38
@@ -1779,6 +1776,11 @@ packages:
 
   /@next/env@14.2.4:
     resolution: {integrity: sha512-3EtkY5VDkuV2+lNmKlbkibIJxcO4oIHEhBWne6PaAp+76J9KoSsGvNikp6ivzAT8dhhBMYrm6op2pS1ApG0Hzg==}
+    dev: false
+
+  /@next/env@14.2.5:
+    resolution: {integrity: sha512-/zZGkrTOsraVfYjGP8uM0p6r0BDT6xWpkjdVbcz66PJVSpwXX3yNiRycxAuDfBKGWBrZBXRuK/YVlkNgxHGwmA==}
+    dev: true
 
   /@next/swc-darwin-arm64@14.2.4:
     resolution: {integrity: sha512-AH3mO4JlFUqsYcwFUHb1wAKlebHU/Hv2u2kb1pAuRanDZ7pD/A/KPD98RHZmwsJpdHQwfEc/06mgpSzwrJYnNg==}
@@ -1786,6 +1788,16 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-darwin-arm64@14.2.5:
+    resolution: {integrity: sha512-/9zVxJ+K9lrzSGli1///ujyRfon/ZneeZ+v4ptpiPoOU+GKZnm8Wj8ELWU1Pm7GHltYRBklmXMTUqM/DqQ99FQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@next/swc-darwin-x64@14.2.4:
@@ -1794,6 +1806,16 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-darwin-x64@14.2.5:
+    resolution: {integrity: sha512-vXHOPCwfDe9qLDuq7U1OYM2wUY+KQ4Ex6ozwsKxp26BlJ6XXbHleOUldenM67JRyBfVjv371oneEvYd3H2gNSA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@next/swc-linux-arm64-gnu@14.2.4:
@@ -1802,6 +1824,16 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-linux-arm64-gnu@14.2.5:
+    resolution: {integrity: sha512-vlhB8wI+lj8q1ExFW8lbWutA4M2ZazQNvMWuEDqZcuJJc78iUnLdPPunBPX8rC4IgT6lIx/adB+Cwrl99MzNaA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@next/swc-linux-arm64-musl@14.2.4:
@@ -1810,6 +1842,16 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-linux-arm64-musl@14.2.5:
+    resolution: {integrity: sha512-NpDB9NUR2t0hXzJJwQSGu1IAOYybsfeB+LxpGsXrRIb7QOrYmidJz3shzY8cM6+rO4Aojuef0N/PEaX18pi9OA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@next/swc-linux-x64-gnu@14.2.4:
@@ -1818,6 +1860,16 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-linux-x64-gnu@14.2.5:
+    resolution: {integrity: sha512-8XFikMSxWleYNryWIjiCX+gU201YS+erTUidKdyOVYi5qUQo/gRxv/3N1oZFCgqpesN6FPeqGM72Zve+nReVXQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@next/swc-linux-x64-musl@14.2.4:
@@ -1826,6 +1878,16 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-linux-x64-musl@14.2.5:
+    resolution: {integrity: sha512-6QLwi7RaYiQDcRDSU/os40r5o06b5ue7Jsk5JgdRBGGp8l37RZEh9JsLSM8QF0YDsgcosSeHjglgqi25+m04IQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@next/swc-win32-arm64-msvc@14.2.4:
@@ -1834,6 +1896,16 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-win32-arm64-msvc@14.2.5:
+    resolution: {integrity: sha512-1GpG2VhbspO+aYoMOQPQiqc/tG3LzmsdBH0LhnDS3JrtDx2QmzXe0B6mSZZiN3Bq7IOMXxv1nlsjzoS1+9mzZw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@next/swc-win32-ia32-msvc@14.2.4:
@@ -1842,6 +1914,16 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-win32-ia32-msvc@14.2.5:
+    resolution: {integrity: sha512-Igh9ZlxwvCDsu6438FXlQTHlRno4gFpJzqPjSIBZooD22tKeI4fE/YMRoHVJHmrQ2P5YL1DoZ0qaOKkbeFWeMg==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@next/swc-win32-x64-msvc@14.2.4:
@@ -1850,6 +1932,16 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-win32-x64-msvc@14.2.5:
+    resolution: {integrity: sha512-tEQ7oinq1/CjSG9uSTerca3v4AZ+dFa+4Yu6ihaG8Ud8ddqLQgFGcnwYls13H5X5CPDPZJdYxyeMui6muOLd4g==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@nodelib/fs.scandir@2.1.5:
@@ -4356,11 +4448,6 @@ packages:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
     dev: false
 
-  /http-body@1.0.12:
-    resolution: {integrity: sha512-Od1kmXULmtr+avRyXD8EfsjlUeZ+pBLsykNDi63bHJZpjr1oQZEmJiTDtIZRfzppxZO+FljLMN4aROOzeQVpRQ==}
-    engines: {node: '>= 18'}
-    dev: true
-
   /http-cache-semantics@4.1.1:
     resolution: {integrity: sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==}
     dev: true
@@ -4813,7 +4900,7 @@ packages:
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.2(@types/node@16.18.40)(typescript@5.5.3)
+      ts-node: 10.9.2(@types/node@16.18.40)(typescript@5.5.4)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -6389,6 +6476,49 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+    dev: false
+
+  /next@14.2.5(@babel/core@7.20.12)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-0f8aRfBVL+mpzfBjYfQuLWh2WyAwtJXCRfkPF4UJ5qd2YwrHczsrSzXU4tRMV0OAxR8ZJZWPFn6uhSC56UTsLA==}
+    engines: {node: '>=18.17.0'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.41.2
+      react: ^18.2.0
+      react-dom: ^18.2.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      sass:
+        optional: true
+    dependencies:
+      '@next/env': 14.2.5
+      '@swc/helpers': 0.5.5
+      busboy: 1.6.0
+      caniuse-lite: 1.0.30001600
+      graceful-fs: 4.2.11
+      postcss: 8.4.31
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      styled-jsx: 5.1.1(@babel/core@7.20.12)(react@18.3.1)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 14.2.5
+      '@next/swc-darwin-x64': 14.2.5
+      '@next/swc-linux-arm64-gnu': 14.2.5
+      '@next/swc-linux-arm64-musl': 14.2.5
+      '@next/swc-linux-x64-gnu': 14.2.5
+      '@next/swc-linux-x64-musl': 14.2.5
+      '@next/swc-win32-arm64-msvc': 14.2.5
+      '@next/swc-win32-ia32-msvc': 14.2.5
+      '@next/swc-win32-x64-msvc': 14.2.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+    dev: true
 
   /nextra-theme-docs@2.13.4(next@14.2.4)(nextra@2.13.4)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-2XOoMfwBCTYBt8ds4ZHftt9Wyf2XsykiNo02eir/XEYB+sGeUoE77kzqfidjEOKCSzOHYbK9BDMcg2+B/2vYRw==}
@@ -6848,7 +6978,7 @@ packages:
     dependencies:
       lilconfig: 2.1.0
       postcss: 8.4.39
-      ts-node: 10.9.2(@types/node@16.18.40)(typescript@5.5.3)
+      ts-node: 10.9.2(@types/node@16.18.40)(typescript@5.5.4)
       yaml: 2.3.1
     dev: true
 
@@ -6912,8 +7042,8 @@ packages:
     hasBin: true
     dev: true
 
-  /prettier@3.3.2:
-    resolution: {integrity: sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==}
+  /prettier@3.3.3:
+    resolution: {integrity: sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==}
     engines: {node: '>=14'}
     hasBin: true
     dev: true
@@ -7895,7 +8025,7 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /ts-jest@29.2.2(@babel/core@7.20.12)(@jest/types@29.5.0)(esbuild@0.23.0)(jest@29.7.0)(typescript@5.5.3):
+  /ts-jest@29.2.2(@babel/core@7.20.12)(@jest/types@29.5.0)(esbuild@0.23.0)(jest@29.7.0)(typescript@5.5.4):
     resolution: {integrity: sha512-sSW7OooaKT34AAngP6k1VS669a0HdLxkQZnlC7T76sckGCokXFnvJ3yRlQZGRTAoV5K19HfSgCiSwWOSIfcYlg==}
     engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -7931,11 +8061,11 @@ packages:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.5.4
-      typescript: 5.5.3
+      typescript: 5.5.4
       yargs-parser: 21.1.1
     dev: true
 
-  /ts-node@10.9.2(@types/node@16.18.40)(typescript@5.5.3):
+  /ts-node@10.9.2(@types/node@16.18.40)(typescript@5.5.4):
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
     hasBin: true
     peerDependencies:
@@ -7961,7 +8091,7 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.5.3
+      typescript: 5.5.4
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: true
@@ -7974,7 +8104,7 @@ packages:
     deprecated: no longer maintained
     dev: true
 
-  /tsup@8.0.1(ts-node@10.9.2)(typescript@5.5.3):
+  /tsup@8.0.1(ts-node@10.9.2)(typescript@5.5.4):
     resolution: {integrity: sha512-hvW7gUSG96j53ZTSlT4j/KL0q1Q2l6TqGBFc6/mu/L46IoNWqLLUzLRLP1R8Q7xrJTmkDxxDoojV5uCVs1sVOg==}
     engines: {node: '>=18'}
     hasBin: true
@@ -8007,7 +8137,7 @@ packages:
       source-map: 0.8.0-beta.0
       sucrase: 3.32.0
       tree-kill: 1.2.2
-      typescript: 5.5.3
+      typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
       - ts-node
@@ -8130,8 +8260,8 @@ packages:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
     dev: true
 
-  /typescript@5.5.3:
-    resolution: {integrity: sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==}
+  /typescript@5.5.4:
+    resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true


### PR DESCRIPTION
`Headers.prototype.entries` was different from `Headers.prototype[Symbol.iteartor]`. This is probably a fairly new implementation in undici that handles set-cookie headers, so I removed the custom `entries()` function.

This resolves EC-2421