### PR TITLE
Remove access to `Buffer` in `@edge-runtime/jest-environment`

### DIFF
--- a/packages/jest-environment/src/index.ts
+++ b/packages/jest-environment/src/index.ts
@@ -19,7 +19,6 @@ class EdgeEnvironment implements JestEnvironment<number> {
     const vm = new EdgeVM({
       extend: (context) => {
         context.global = context
-        context.Buffer = Buffer
         return context
       },
       ...((config as any).projectConfig ?? config)?.testEnvironmentOptions,

--- a/packages/jest-environment/test/index.test.ts
+++ b/packages/jest-environment/test/index.test.ts
@@ -19,3 +19,7 @@ test('allows to run crypto', async () => {
 test('has EdgeRuntime global', () => {
   expect(EdgeRuntime).toEqual('edge-runtime')
 })
+
+test('does not have access to node global variables', () => {
+  expect(typeof Buffer).toEqual('undefined')
+})


### PR DESCRIPTION
Removes access to global `Buffer` variable from Node when using `@edge-runtime/jest-environment`.

`Buffer` will not be available in production when using the edge runtime, so it should also be unavailable in tests. That way, we can catch in tests when unavailable APIs are used.