### PR TITLE
Allow setting cookies with special characters

### DIFF
--- a/packages/cookies/src/serialize.ts
+++ b/packages/cookies/src/serialize.ts
@@ -1,5 +1,13 @@
 import type { RequestCookie, ResponseCookie } from './types'
 
+function maybeDecodeURIComponent(s: string) {
+  try {
+    return decodeURIComponent(s)
+  } catch {
+    return s
+  }
+}
+
 export function stringifyCookie(c: ResponseCookie | RequestCookie): string {
   const attrs = [
     'path' in c && c.path && `Path=${c.path}`,
@@ -19,7 +27,9 @@ export function stringifyCookie(c: ResponseCookie | RequestCookie): string {
   ].filter(Boolean)
 
   const stringified = `${c.name}=${encodeURIComponent(c.value ?? '')}`
-  return attrs.length === 0 ? stringified : `${stringified}; ${attrs.join('; ')}`
+  return attrs.length === 0
+    ? stringified
+    : `${stringified}; ${attrs.join('; ')}`
 }
 
 /** Parse a `Cookie` header value */
@@ -72,7 +82,9 @@ export function parseSetCookie(setCookie: string): undefined | ResponseCookie {
   )
   const cookie: ResponseCookie = {
     name,
-    value: decodeURIComponent(value),
+    // parseCookie already decoded the value, so if the value contains special chars
+    // decoding it again will cause problems
+    value: maybeDecodeURIComponent(value),
     domain,
     ...(expires && { expires: new Date(expires) }),
     ...(httponly && { httpOnly: true }),

--- a/packages/cookies/test/response-cookies.test.ts
+++ b/packages/cookies/test/response-cookies.test.ts
@@ -262,3 +262,16 @@ test('splitting multiple set-cookie', () => {
   expect(cookies2.get('foo')?.value).toBe(undefined)
   expect(cookies2.get('fooz')?.value).toBe('barz')
 })
+
+test('cookie with special chars', () => {
+  const headers = new Headers()
+  const specialChars = 'bar 50%!@#$%^&*()_+'
+  headers.set(
+    'set-cookie',
+    `foo=${JSON.stringify({ 'val': encodeURIComponent(specialChars) })}`,
+  )
+  const cookies = new ResponseCookies(headers)
+  expect(cookies.getAll()).toEqual([
+    { name: 'foo', value: `{"val":"${specialChars}"}` },
+  ])
+})


### PR DESCRIPTION
This is a fix for https://github.com/vercel/next.js/issues/70523

### What?
Access the `ResponseCookie` object using the `NextResponse` class in a nextjs middleware like so:
```ts
const response = NextResponse.next()
const data = {
  value: "bar 50%"
}

response.cookies.set({
  name: 'foo',
  value: JSON.stringify(data)
})
```
You'll notice that the cookie being set crashes the application. The reason for this is explained below:
- `ResponseCookie`'s constructor calls the `parseSetCookie` method: https://github.com/vercel/edge-runtime/blob/8312ccd3e507aa8683b3705f2ca2d9862183982b/packages/cookies/src/response-cookies.ts#L31-L33
- `parseSetCookie` function calls the `parseCookie` function: https://github.com/vercel/edge-runtime/blob/8312ccd3e507aa8683b3705f2ca2d9862183982b/packages/cookies/src/serialize.ts#L54-L59
- `parseCookie` calls the `decodeURIComponent` function on the cookie value: https://github.com/vercel/edge-runtime/blob/8312ccd3e507aa8683b3705f2ca2d9862183982b/packages/cookies/src/serialize.ts#L42-L44
- `parseSetCookie` function again calls the `decodeURIComponent` function on line 75: https://github.com/vercel/edge-runtime/blob/8312ccd3e507aa8683b3705f2ca2d9862183982b/packages/cookies/src/serialize.ts#L73-L76

This double invocation of `decodeURIComponent` throws an error and crashes the application if the cookie contains special characters. 