### PR TITLE
fix: parse max-age in set cookie

### DIFF
--- a/.changeset/big-pumpkins-kiss.md
+++ b/.changeset/big-pumpkins-kiss.md
@@ -1,0 +1,5 @@
+---
+'@edge-runtime/cookies': patch
+---
+
+Fix parsing max-age in set cookie

--- a/packages/cookies/src/serialize.ts
+++ b/packages/cookies/src/serialize.ts
@@ -19,7 +19,9 @@ export function stringifyCookie(c: ResponseCookie | RequestCookie): string {
   ].filter(Boolean)
 
   const stringified = `${c.name}=${encodeURIComponent(c.value ?? '')}`
-  return attrs.length === 0 ? stringified : `${stringified}; ${attrs.join('; ')}`
+  return attrs.length === 0
+    ? stringified
+    : `${stringified}; ${attrs.join('; ')}`
 }
 
 /** Parse a `Cookie` header value */
@@ -68,7 +70,10 @@ export function parseSetCookie(setCookie: string): undefined | ResponseCookie {
     partitioned,
     priority,
   } = Object.fromEntries(
-    attributes.map(([key, value]) => [key.toLowerCase(), value]),
+    attributes.map(([key, value]) => [
+      key.toLowerCase().replace(/-/g, ''),
+      value,
+    ]),
   )
   const cookie: ResponseCookie = {
     name,

--- a/packages/cookies/test/response-cookies.test.ts
+++ b/packages/cookies/test/response-cookies.test.ts
@@ -278,3 +278,12 @@ test('splitting multiple set-cookie', () => {
   expect(cookies2.get('foo')?.value).toBe(undefined)
   expect(cookies2.get('fooz')?.value).toBe('barz')
 })
+
+test('parse max-age from set-cookie', () => {
+  const headers = new Headers()
+  headers.set('set-cookie', 'foo=bar; Max-Age=1000')
+
+  const cookies = new ResponseCookies(headers)
+  expect(cookies.get('foo')?.value).toBe('bar')
+  expect(cookies.get('foo')?.maxAge).toBe(1000)
+})


### PR DESCRIPTION
Fixes #941 