### PR TITLE
[format] print stack trace by default

### DIFF
--- a/.changeset/tasty-cats-eat.md
+++ b/.changeset/tasty-cats-eat.md
@@ -1,0 +1,5 @@
+---
+'@edge-runtime/format': patch
+---
+
+print stack trace by default when logging errors

--- a/packages/format/src/index.ts
+++ b/packages/format/src/index.ts
@@ -257,10 +257,6 @@ export function createFormat(opts: FormatterOptions = {}) {
         base = ' ' + base
       } else if (isError(value)) {
         base = formatError(value)
-        if (keys.length === 0) {
-          return base
-        }
-        base = ' ' + base
       } else if (hasCustomSymbol(value, ctx.customInspectSymbol)) {
         base = format(value[ctx.customInspectSymbol]({ format }))
         if (keys.length === 0) {

--- a/packages/format/src/index.ts
+++ b/packages/format/src/index.ts
@@ -257,6 +257,7 @@ export function createFormat(opts: FormatterOptions = {}) {
         base = ' ' + base
       } else if (isError(value)) {
         base = formatError(value)
+        keys = keys.filter((x) => x !== 'name')
       } else if (hasCustomSymbol(value, ctx.customInspectSymbol)) {
         base = format(value[ctx.customInspectSymbol]({ format }))
         if (keys.length === 0) {

--- a/packages/format/src/index.ts
+++ b/packages/format/src/index.ts
@@ -43,8 +43,10 @@ export function createFormat(opts: FormatterOptions = {}) {
   }
 
   if (opts.formatError === undefined) {
-    opts.formatError = (error: Error) =>
-      `[${Error.prototype.toString.call(error)}]`
+    opts.formatError = (error: Error) => {
+      const stack = error.stack ?? Error.prototype.toString.call(error)
+      return String(stack)
+    }
   }
 
   const { formatError, customInspectSymbol } = opts

--- a/packages/format/tests/index.test.ts
+++ b/packages/format/tests/index.test.ts
@@ -29,7 +29,7 @@ it('first argument', () => {
   expect(format({ [Symbol('a')]: 1 })).toBe('{ [Symbol(a)]: 1 }')
   expect(format(new Date(123))).toBe('1970-01-01T00:00:00.123Z')
   expect(format(new Date('asdf'))).toBe('Invalid Date')
-  expect(format(new Error('oh no'))).toBe('[Error: oh no]')
+  expect(format(new Error('oh no'))).toMatch(/^Error: oh no.+at Object\./ms)
   expect(
     format(
       (() => {
@@ -202,7 +202,7 @@ it('string (%s)', () => {
   expect(format('%s:%s', 'foo', 'bar')).toBe('foo:bar')
   expect(format('foo', 'bar', 'baz')).toBe('foo bar baz')
   expect(format('%s:%s', undefined)).toBe('undefined:%s')
-  expect(format('%s', new Error('oh no'))).toBe('[Error: oh no]')
+  expect(format('%s', new Error('oh no'))).toMatch(/^Error: oh no\n\s+at /)
   expect(format('%s:%s', 'foo', 'bar', 'baz')).toBe('foo:bar baz')
   expect(format('%s', function greetings() {})).toBe('function greetings() { }')
   ;(() => {
@@ -213,8 +213,8 @@ it('string (%s)', () => {
     class CustomError extends Error {
       readonly name = 'CustomError'
     }
-    expect(format(new CustomError('bar'))).toBe(
-      "[CustomError: bar] { name: 'CustomError' }",
+    expect(format(new CustomError('bar'))).toMatch(
+      /^CustomError: bar.+at .+\{.+name: 'CustomError'.+\}$/ms,
     )
   })()
   ;(() => {
@@ -259,8 +259,8 @@ it('object generic (%O)', () => {
   expect(format('%O', /foo/g)).toBe('/foo/g')
   expect(format('%O', { foo: 'bar' })).toBe("{ foo: 'bar' }")
   expect(format('%O', [1, 2, 3])).toBe('[ 1, 2, 3 ]')
-  expect(format('%O', { error: new Error('oh no') })).toBe(
-    '{ error: [Error: oh no] }',
+  expect(format('%O', { error: new Error('oh no') })).toMatch(
+    /\{.+error: Error: oh no\n.+\}/ms,
   )
   expect(format('%O', { date: new Date(123) })).toBe(
     '{ date: 1970-01-01T00:00:00.123Z }',
@@ -281,7 +281,7 @@ it('object (%o)', () => {
     const error = new Error('mock error')
     delete error.stack
     expect(format('%o', error)).toBe(
-      "[Error: mock error] { message: 'mock error' }",
+      "Error: mock error { message: 'mock error' }",
     )
   })()
 

--- a/packages/format/tests/index.test.ts
+++ b/packages/format/tests/index.test.ts
@@ -214,7 +214,7 @@ it('string (%s)', () => {
       readonly name = 'CustomError'
     }
     expect(format(new CustomError('bar'))).toMatch(
-      /^CustomError: bar.+at .+\{.+name: 'CustomError'.+\}$/ms,
+      /^CustomError: bar.+at .+$/ms,
     )
   })()
   ;(() => {

--- a/packages/vm/tests/integration/error.test.ts
+++ b/packages/vm/tests/integration/error.test.ts
@@ -40,9 +40,9 @@ test('additional error properties', async () => {
   expect(log).toHaveBeenCalledTimes(2)
   const [[withoutCause], [withCause]] = log.mock.calls
   expect(withoutCause).toMatch(
-    /^CustomError: without cause\s+at fn.+\{.+digest: 'digest1',.+cause: undefined,.+name: 'CustomError'.+\}/ms,
+    /^CustomError: without cause\s+at fn.+\{.+digest: 'digest1',.+cause: undefined.+\}/ms,
   )
   expect(withCause).toMatch(
-    /^CustomError: with cause\s+at fn.+\{.+digest: 'digest2',.+cause: Error: oh no.+,.+name: 'CustomError'.+\}/ms,
+    /^CustomError: with cause\s+at fn.+\{.+digest: 'digest2',.+cause: Error: oh no.+.+\}/ms,
   )
 })

--- a/packages/vm/tests/integration/error.test.ts
+++ b/packages/vm/tests/integration/error.test.ts
@@ -1,0 +1,16 @@
+import { EdgeVM } from '../../src'
+
+test('Error maintains a stack trace', async () => {
+  const log = jest.fn()
+  console.log = log
+
+  function fn() {
+    console.log(new Error('hello, world!'))
+  }
+
+  const vm = new EdgeVM()
+  vm.evaluate(`(${fn})()`)
+
+  expect(log).toHaveBeenCalledTimes(1)
+  expect(log.mock.lastCall[0]).toMatch(/^Error: hello, world!\s+at fn/m)
+})

--- a/packages/vm/tests/integration/error.test.ts
+++ b/packages/vm/tests/integration/error.test.ts
@@ -14,3 +14,35 @@ test('Error maintains a stack trace', async () => {
   expect(log).toHaveBeenCalledTimes(1)
   expect(log.mock.lastCall[0]).toMatch(/^Error: hello, world!\s+at fn/m)
 })
+
+test('additional error properties', async () => {
+  const log = jest.fn()
+  console.log = log
+
+  function fn() {
+    class CustomError extends Error {
+      name = 'CustomError'
+      constructor(
+        message: string,
+        private digest: string,
+        private cause?: Error,
+      ) {
+        super(message)
+      }
+    }
+    console.log(new CustomError('without cause', 'digest1'))
+    console.log(new CustomError('with cause', 'digest2', new Error('oh no')))
+  }
+
+  const vm = new EdgeVM()
+  vm.evaluate(`(${fn})()`)
+
+  expect(log).toHaveBeenCalledTimes(2)
+  const [[withoutCause], [withCause]] = log.mock.calls
+  expect(withoutCause).toMatch(
+    /^CustomError: without cause\s+at fn.+\{.+digest: 'digest1',.+cause: undefined,.+name: 'CustomError'.+\}/ms,
+  )
+  expect(withCause).toMatch(
+    /^CustomError: with cause\s+at fn.+\{.+digest: 'digest2',.+cause: Error: oh no.+,.+name: 'CustomError'.+\}/ms,
+  )
+})


### PR DESCRIPTION
- **[format] breaking: print stack trace when logging errors**
- **add changeset**

Closes https://github.com/vercel/edge-runtime/issues/108