### PR TITLE
force bump primitives

### DIFF
--- a/.changeset/sweet-trees-press.md
+++ b/.changeset/sweet-trees-press.md
@@ -1,0 +1,5 @@
+---
+'@edge-runtime/primitives': patch
+---
+
+force bumping primitives as format changed and it didn't trigger a rebuild


### PR DESCRIPTION
#1025 was merged but we haven't declared a changeset for `@edge-runtime/primitives` so it wasn't released (seems like Changesets doesn't do what we want it to do)

This PR forces to bump primitives:

```
🦋  info Packages to be bumped at patch:
🦋  info
🦋  - @edge-runtime/primitives
🦋  - @edge-runtime/types
🦋  - @edge-runtime/vm
🦋  - @edge-runtime/jest-environment
🦋  - edge-runtime
🦋  ---
🦋  info NO packages to be bumped at minor
🦋  ---
🦋  info NO packages to be bumped at major
```
