### PR TITLE
Release new versions of packages bundling `@edge-runtime/format`

### DIFF
--- a/.changeset/lovely-pots-relax.md
+++ b/.changeset/lovely-pots-relax.md
@@ -1,0 +1,6 @@
+---
+'@edge-runtime/cookies': patch
+'@edge-runtime/primitives': patch
+---
+
+Print stack trace by default


### PR DESCRIPTION
Packages bundling `@edge-runtime/format` need to be explicitly listed in the changesets since in those packages `/format` is only a dev dependency.

`edge-runtime` lists `/format` as a direct dependency so Changesets automatically bumps it.

See https://github.com/changesets/changesets/issues/944