### PR TITLE
Fix: Convert cookie attribute "sameSite" of TRUE to "strict" as per documentation

### DIFF
--- a/packages/cookies/src/serialize.ts
+++ b/packages/cookies/src/serialize.ts
@@ -13,7 +13,9 @@ export function stringifyCookie(c: ResponseCookie | RequestCookie): string {
     'domain' in c && c.domain && `Domain=${c.domain}`,
     'secure' in c && c.secure && 'Secure',
     'httpOnly' in c && c.httpOnly && 'HttpOnly',
-    'sameSite' in c && c.sameSite && `SameSite=${c.sameSite}`,
+    'sameSite' in c &&
+      c.sameSite &&
+      `SameSite=${c.sameSite === true ? 'strict' : c.sameSite}`,
     'partitioned' in c && c.partitioned && 'Partitioned',
     'priority' in c && c.priority && `Priority=${c.priority}`,
   ].filter(Boolean)

--- a/packages/cookies/src/serialize.ts
+++ b/packages/cookies/src/serialize.ts
@@ -13,9 +13,7 @@ export function stringifyCookie(c: ResponseCookie | RequestCookie): string {
     'domain' in c && c.domain && `Domain=${c.domain}`,
     'secure' in c && c.secure && 'Secure',
     'httpOnly' in c && c.httpOnly && 'HttpOnly',
-    'sameSite' in c &&
-      c.sameSite &&
-      `SameSite=${c.sameSite === true ? 'strict' : c.sameSite}`,
+    'sameSite' in c && c.sameSite && `SameSite=${c.sameSite === true ? 'strict' : c.sameSite}`,
     'partitioned' in c && c.partitioned && 'Partitioned',
     'priority' in c && c.priority && `Priority=${c.priority}`,
   ].filter(Boolean)


### PR DESCRIPTION
This PR addresses the following issue:

Per documentation, the cookie attribute sameSite should convert the boolean value of "true" to "strict".

This is not the case. Instead, a cookie will have an invalid value, e.g.

`session=anyvalue; Path=/; SameSite=true`

expected cookie String should (per documentation) should be

`session=anyvalue; Path=/; SameSite=strict`

 This patch converts the boolean true to "strict" as per documentation.