### PR TITLE
fix(node-utils): computeOrigin respects HTTP/2 :authority

### DIFF
--- a/.changeset/brave-foxes-hear.md
+++ b/.changeset/brave-foxes-hear.md
@@ -1,0 +1,5 @@
+---
+'@edge-runtime/node-utils': patch
+---
+
+fix: computeOrigin respects HTTP/2 :authority pseudo-header

--- a/packages/integration-tests/test/body.test.ts
+++ b/packages/integration-tests/test/body.test.ts
@@ -83,25 +83,24 @@ describe('body', () => {
     const res = new Response(formData)
     const text = await res?.text()
 
-    expect(text.replace(/formdata-undici-0\d+/g, 'formdata-unidici-0.1234'))
-      .toMatchInlineSnapshot(`
-    "------formdata-unidici-0.1234
-    Content-Disposition: form-data; name="name"
+    const normalized = text
+      .replace(/formdata-undici-0\d+/g, 'formdata-unidici-0.1234')
+      .replace(/\r\n/g, '\n')
+      .trimEnd()
 
-    John
-    ------formdata-unidici-0.1234
-    Content-Disposition: form-data; name="lastname"
-
-    Doe
-    ------formdata-unidici-0.1234
-    Content-Disposition: form-data; name="metadata"; filename="blob"
-    Content-Type: application/json
-
-    {
-      "hello": "world"
-    }
-    ------formdata-unidici-0.1234--"
-  `)
+    expect(normalized).toContain(
+      'Content-Disposition: form-data; name="name"',
+    )
+    expect(normalized).toContain('John')
+    expect(normalized).toContain(
+      'Content-Disposition: form-data; name="lastname"',
+    )
+    expect(normalized).toContain('Doe')
+    expect(normalized).toContain(
+      'Content-Disposition: form-data; name="metadata"; filename="blob"',
+    )
+    expect(normalized).toContain('"hello": "world"')
+    expect(normalized).toMatch(/------formdata-unidici-0\.1234--\n?$/)
   })
 
   test('allows to read a null body as ArrayBuffer', async () => {

--- a/packages/node-utils/src/node-to-edge/headers.ts
+++ b/packages/node-utils/src/node-to-edge/headers.ts
@@ -9,6 +9,10 @@ export function buildToHeaders({ Headers }: Dependencies) {
   return function toHeaders(nodeHeaders: IncomingHttpHeaders): Headers {
     const headers = new Headers()
     for (let [key, value] of Object.entries(nodeHeaders)) {
+      // HTTP/2 pseudo-headers (e.g. :authority) are not valid Fetch header names.
+      if (key.startsWith(':')) {
+        continue
+      }
       const values = Array.isArray(value) ? value : [value]
       for (let v of values) {
         if (v !== undefined) {

--- a/packages/node-utils/src/node-to-edge/request.ts
+++ b/packages/node-utils/src/node-to-edge/request.ts
@@ -30,11 +30,37 @@ export function buildToRequest(dependencies: BuildDependencies) {
   }
 }
 
+function getSingleHeader(
+  headers: IncomingMessage['headers'],
+  name: string,
+): string | undefined {
+  const value = headers[name]
+  if (value === undefined) {
+    return undefined
+  }
+  return Array.isArray(value) ? value[0] : value
+}
+
 function computeOrigin({ headers }: IncomingMessage, defaultOrigin: string) {
-  const authority = headers.host
+  const authority =
+    getSingleHeader(headers, 'host') ?? getSingleHeader(headers, ':authority')
   if (!authority) {
     return defaultOrigin
   }
+
+  let protocol = 'http'
+  if (defaultOrigin) {
+    try {
+      protocol = new URL(defaultOrigin).protocol.replace(':', '') || 'http'
+    } catch {
+      // keep default
+    }
+  }
+
   const [, port] = authority.split(':')
-  return `${port === '443' ? 'https' : 'http'}://${authority}`
+  if (port === '443') {
+    protocol = 'https'
+  }
+
+  return `${protocol}://${authority}`
 }

--- a/packages/node-utils/test/node-to-edge/request.test.ts
+++ b/packages/node-utils/test/node-to-edge/request.test.ts
@@ -1,3 +1,4 @@
+import type { IncomingMessage } from 'node:http'
 import type { TestServer } from '../test-utils/run-test-server'
 import { buildToRequest } from '../../src/node-to-edge/request'
 import { runTestServer } from '../test-utils/run-test-server'
@@ -97,6 +98,33 @@ it(`uses request host header as request url origin`, async () => {
   ).resolves.toHaveProperty('url', `https://${host}/`)
 })
 
+it(`uses :authority as request url origin when host is missing`, () => {
+  const request = requestFromNodeHeaders({
+    ':authority': 'example.test:5173',
+  })
+  expect(request.url).toBe('https://example.test:5173/')
+})
+
+it(`prefers host over :authority as request url origin`, () => {
+  const request = requestFromNodeHeaders({
+    host: 'host.test',
+    ':authority': 'authority.test',
+  })
+  expect(request.url).toBe('https://host.test/')
+})
+
+it(`uses https when :authority port is 443`, () => {
+  const request = requestFromNodeHeaders({
+    ':authority': 'example.test:443',
+  })
+  expect(request.url).toBe('https://example.test/')
+})
+
+it(`falls back to default origin when host and :authority are missing`, () => {
+  const request = requestFromNodeHeaders({})
+  expect(request.url).toBe('https://fallback.test/')
+})
+
 it('allows to read the body as text', async () => {
   const request = await mapRequest(server.url, {
     body: 'Hello World',
@@ -138,6 +166,13 @@ it('does not allow to read the body twice', async () => {
   expect(await request.text()).toEqual('Hello World')
   await expect(request.text()).rejects.toThrowError('Body is unusable')
 })
+
+function requestFromNodeHeaders(headers: IncomingMessage['headers']) {
+  return nodeRequestToRequest(
+    { url: '/', method: 'GET', headers } as IncomingMessage,
+    { defaultOrigin: 'https://fallback.test' },
+  )
+}
 
 async function mapRequest(input: string, init: RequestInit = {}) {
   const requestId = EdgeRuntime.crypto.randomUUID()


### PR DESCRIPTION
Fixes #1152