### PR TITLE
fix(cookies): parse percent values in set-cookie headers

### DIFF
--- a/.changeset/tidy-cycles-carry.md
+++ b/.changeset/tidy-cycles-carry.md
@@ -1,0 +1,5 @@
+---
+'@edge-runtime/cookies': patch
+---
+
+Fix `Set-Cookie` parsing for values containing percent characters.

--- a/packages/cookies/src/serialize.ts
+++ b/packages/cookies/src/serialize.ts
@@ -58,7 +58,13 @@ export function parseSetCookie(setCookie: string): undefined | ResponseCookie {
     return undefined
   }
 
-  const [[name, value], ...attributes] = parseCookie(setCookie)
+  const [cookiePair, ...attributePairs] = setCookie.split(/; */)
+  const splitAt = cookiePair.indexOf('=')
+  const [name, value] =
+    splitAt === -1
+      ? [cookiePair, 'true']
+      : [cookiePair.slice(0, splitAt), cookiePair.slice(splitAt + 1)]
+  const attributes = parseCookie(attributePairs.join('; '))
   const {
     domain,
     expires,
@@ -70,14 +76,14 @@ export function parseSetCookie(setCookie: string): undefined | ResponseCookie {
     partitioned,
     priority,
   } = Object.fromEntries(
-    attributes.map(([key, value]) => [
+    Array.from(attributes).map(([key, value]) => [
       key.toLowerCase().replace(/-/g, ''),
       value,
     ]),
   )
   const cookie: ResponseCookie = {
     name,
-    value: decodeURIComponent(value),
+    value: decodeCookieValue(value),
     domain,
     ...(expires && { expires: new Date(expires) }),
     ...(httponly && { httpOnly: true }),
@@ -90,6 +96,14 @@ export function parseSetCookie(setCookie: string): undefined | ResponseCookie {
   }
 
   return compact(cookie)
+}
+
+function decodeCookieValue(value: string) {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
 }
 
 function compact<T>(t: T): T {

--- a/packages/cookies/test/response-cookies.test.ts
+++ b/packages/cookies/test/response-cookies.test.ts
@@ -1,5 +1,6 @@
 import { createFormat } from '@edge-runtime/format'
 import { ResponseCookies } from '../src/response-cookies'
+import { parseSetCookie } from '../src/serialize'
 
 test('reflect .set into `set-cookie`', async () => {
   const headers = new Headers()
@@ -286,4 +287,63 @@ test('parse max-age from set-cookie', () => {
   const cookies = new ResponseCookies(headers)
   expect(cookies.get('foo')?.value).toBe('bar')
   expect(cookies.get('foo')?.maxAge).toBe(1000)
+})
+
+test('parse percent encoded set-cookie values once', () => {
+  expect(parseSetCookie('foo=%25; Path=/')).toEqual({
+    name: 'foo',
+    value: '%',
+    path: '/',
+  })
+})
+
+test('preserve malformed percent set-cookie values', () => {
+  expect(parseSetCookie('foo=%; Path=/')).toEqual({
+    name: 'foo',
+    value: '%',
+    path: '/',
+  })
+})
+
+test('preserve set-cookie values without percent decoding regressions', () => {
+  expect(parseSetCookie('foo; Path=/')).toEqual({
+    name: 'foo',
+    value: 'true',
+    path: '/',
+  })
+  expect(parseSetCookie('foo=a=b; Path=/')).toEqual({
+    name: 'foo',
+    value: 'a=b',
+    path: '/',
+  })
+})
+
+test('parse percent values from response set-cookie headers', () => {
+  const headers = new Headers()
+  headers.set('set-cookie', 'foo=%25; Path=/')
+  headers.append('set-cookie', 'bar=baz; Path=/test')
+
+  const cookies = new ResponseCookies(headers)
+  expect(cookies.get('foo')).toEqual({
+    name: 'foo',
+    value: '%',
+    path: '/',
+  })
+  expect(cookies.get('bar')).toEqual({
+    name: 'bar',
+    value: 'baz',
+    path: '/test',
+  })
+})
+
+test('parse malformed percent values from response set-cookie headers', () => {
+  const headers = new Headers()
+  headers.set('set-cookie', 'foo=%; Path=/')
+
+  const cookies = new ResponseCookies(headers)
+  expect(cookies.get('foo')).toEqual({
+    name: 'foo',
+    value: '%',
+    path: '/',
+  })
 })


### PR DESCRIPTION
## Summary

- parse the first `Set-Cookie` name/value pair without routing it through the request-cookie parser
- decode response cookie values exactly once, falling back to the raw value for malformed percent escapes
- add regressions for `%25`, bare `%`, valueless pairs, and values containing `=`

This fixes the cookie parsing failure reported from Next.js middleware/runtime usage in vercel/next.js#70523.

## Tests

- `pnpm --filter @edge-runtime/cookies build`
- `pnpm --filter @edge-runtime/cookies test`
- `pnpm prettier --check packages/cookies/src/serialize.ts packages/cookies/test/response-cookies.test.ts .changeset/tidy-cycles-carry.md`
- `git diff --check`
